### PR TITLE
Redesign blog with terminal/TUI aesthetic and MVP recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,33 @@
-# Astro Blog Project
+# sinannar.github.io
 
-This project is a personal blog built with [Astro](https://astro.build/), a modern static site generator. It features Markdown and MDX support, custom layouts, and a clean, accessible design.
+Personal site and blog of [Sinan Nar](https://sinannar.github.io) — **Microsoft MVP**, Senior Software Engineer, based in Auckland, NZ.
 
-## Project Structure
-- **src/**: Source files, including components, layouts, pages, and content.
-- **public/**: Static assets such as images and fonts.
-- **astro.config.mjs**: Astro configuration file.
-- **tsconfig.json**: TypeScript configuration.
-- **package.json**: Project dependencies and scripts.
+Built with [Astro](https://astro.build/). The site uses a terminal / TUI-inspired design with a dark-first theme (and a light "paper" theme toggle), JetBrains Mono headings and Inter body type, and Shiki for code highlighting.
 
-## Getting Started
+## Local development
 
-### Prerequisites
-- [Node.js](https://nodejs.org/) (v18 or newer recommended)
-- [npm](https://www.npmjs.com/) or [yarn](https://yarnpkg.com/)
+Requires Node 18+.
 
-### Installation
-1. Clone the repository:
-   ```zsh
-   git clone <your-repo-url>
-   cd <project-directory>
-   ```
-2. Install dependencies:
-   ```zsh
-   npm install
-   # or
-   yarn install
-   ```
-
-### Running the Project Locally
-Start the development server:
-```zsh
-npm run dev
-# or
-yarn dev
-```
-The site will be available at `http://localhost:4321` by default.
-
-### Building for Production
-To build the static site:
-```zsh
-npm run build
-# or
-yarn build
-```
-The output will be in the `dist/` directory.
-
-### Previewing the Production Build
-```zsh
+```bash
+npm install
+npm run dev      # http://localhost:4321
+npm run build    # static build -> ./dist
 npm run preview
-# or
-yarn preview
 ```
 
-## Learn More
-- [Astro Documentation](https://docs.astro.build/)
-- [Markdown Support](https://docs.astro.build/en/guides/markdown-content/)
+## Project layout
 
----
-Feel free to customize this README with more details about your blog, deployment instructions, or contribution guidelines.
+- `src/pages/` — routes (`index`, `about`, `experience`, `certifications`, `speaking`, `blog/`)
+- `src/layouts/BlogPost.astro` — blog post layout (sticky TOC on desktop)
+- `src/components/` — `Header`, `Footer`, `TerminalWindow`, `MvpBadge`, etc.
+- `src/styles/global.css` — design tokens + themes + terminal accents
+- `src/content/blog/` — Markdown / MDX posts
+- `public/` — static assets
+
+## Theming
+
+The theme is set via `data-theme` on the root element and persisted in `localStorage`. The toggle lives in the header. System preference (`prefers-color-scheme`) is honoured on first load.
+
+## License
+
+Content © Sinan Nar. Code is provided as-is.

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -8,4 +8,14 @@ export default defineConfig({
   site: 'https://sinannar.github.io',
   base: '/',
   outDir: 'dist',
+  integrations: [mdx(), sitemap()],
+  markdown: {
+    shikiConfig: {
+      themes: {
+        light: 'github-light',
+        dark: 'github-dark-dimmed',
+      },
+      wrap: true,
+    },
+  },
 });

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -18,6 +18,9 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <!-- Global Metadata -->
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
+<meta name="color-scheme" content="dark light" />
+<meta name="theme-color" content="#0d1117" media="(prefers-color-scheme: dark)" />
+<meta name="theme-color" content="#fafafa" media="(prefers-color-scheme: light)" />
 <link rel="icon" type="image/svg+xml+ico" href="/sinan.ico" />
 <link rel="sitemap" href="/sitemap-index.xml" />
 <link
@@ -28,9 +31,27 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 />
 <meta name="generator" content={Astro.generator} />
 
-<!-- Font preloads -->
-<link rel="preload" href="/fonts/atkinson-regular.woff" as="font" type="font/woff" crossorigin />
-<link rel="preload" href="/fonts/atkinson-bold.woff" as="font" type="font/woff" crossorigin />
+<!-- Fonts: JetBrains Mono (headings, code, prompts) + Inter (body prose) -->
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+	rel="stylesheet"
+	href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap"
+/>
+
+<!-- No-FOUC theme init (set before paint) -->
+<script is:inline>
+	(function () {
+		try {
+			var stored = localStorage.getItem('theme');
+			var prefers = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
+			var theme = stored || prefers;
+			document.documentElement.setAttribute('data-theme', theme);
+		} catch (_) {
+			document.documentElement.setAttribute('data-theme', 'dark');
+		}
+	})();
+</script>
 
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,86 +1,107 @@
 ---
+import { SITE_TITLE, SOCIAL_LINKS } from '../consts';
+
 const today = new Date();
+const iconPaths: Record<string, string> = {
+	x: 'M714 530.6 1156.6 0h-105L661.7 445.7 323.2 0H0l464.2 637.6L0 1227h105.1l412.2-476.2L876.8 1227H1200L714 530.6zm-145.2 167.7-47.7-66.2L87.6 80.7h180.2l292.7 406.1 47.7 66.2 441.5 617.1H869.5L576.8 684.5z',
+	github: 'M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z',
+	linkedin: 'M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.521-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212h2.4V9.359c0-.216.016-.432.08-.586.175-.432.574-.88 1.243-.88.877 0 1.228.664 1.228 1.637v4.864h2.4V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.6 5.6 0 0 1 .016-.025V6.169h-2.4c.03.7 0 7.225 0 7.225z',
+	mail: 'M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2zm13 2.383-4.708 2.825L15 11.118V5.383zM14.247 12H1.753l4.708-4.492 1.039.623a.5.5 0 0 0 .5 0l1.039-.623L14.247 12zM1 11.118l4.708-4.91L1 5.383v5.735z',
+};
+const iconViewBoxes: Record<string, string> = {
+	x: '0 0 1200 1227',
+	github: '0 0 16 16',
+	linkedin: '0 0 16 16',
+	mail: '0 0 16 16',
+};
 ---
 
-<footer>
-	&copy; {today.getFullYear()} Sinan Nar. All rights reserved.
-	<div class="social-links">
-		<a href="https://x.com/snn_nr" target="_blank" title="Twitter/X">
-			<span class="sr-only">Sinan Nar on Twitter/X</span>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="24"
-				height="24"
-				fill="currentColor"
-				viewBox="0 0 1200 1227"
-				><path
-					d="M714 530.6 1156.6 0h-105L661.7 445.7 323.2 0H0l464.2 637.6L0 1227h105.1l412.2-476.2L876.8 1227H1200L714 530.6zm-145.2 167.7-47.7-66.2L87.6 80.7h180.2l292.7 406.1 47.7 66.2 441.5 617.1H869.5L576.8 684.5z"
-				></path></svg
-			>
-		</a>
-		<a href="mailto:sinan.nar@gmail.com" target="_blank" title="Email">
-			<span class="sr-only">Email Sinan Nar</span>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="24"
-				height="24"
-				fill="currentColor"
-				viewBox="0 0 16 16"
-				><path
-					d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2zm13 2.383-4.708 2.825L15 11.118V5.383zM14.247 12H1.753l4.708-4.492 1.039.623a.5.5 0 0 0 .5 0l1.039-.623L14.247 12zM1 11.118l4.708-4.91L1 5.383v5.735z"
-				></path></svg
-			>
-		</a>
-		<a href="https://github.com/sinannar" target="_blank" title="GitHub">
-			<span class="sr-only">Sinan Nar on GitHub</span>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="24"
-				height="24"
-				fill="currentColor"
-				viewBox="0 0 16 16"
-				><path
-					d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-				></path></svg
-			>
-		</a>
-		<a
-			href="https://linkedin.com/in/sinannar"
-			target="_blank"
-			title="LinkedIn"
-		>
-			<span class="sr-only">Sinan Nar on LinkedIn</span>
-			<svg
-				xmlns="http://www.w3.org/2000/svg"
-				width="24"
-				height="24"
-				fill="currentColor"
-				viewBox="0 0 16 16"
-				><path
-					d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.521-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212h2.4V9.359c0-.216.016-.432.08-.586.175-.432.574-.88 1.243-.88.877 0 1.228.664 1.228 1.637v4.864h2.4V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.6 5.6 0 0 1 .016-.025V6.169h-2.4c.03.7 0 7.225 0 7.225z"
-				></path></svg
-			>
-		</a>
+<footer class="site-footer">
+	<div class="footer-inner">
+		<div class="footer-line">
+			<span class="prompt-glyph" aria-hidden="true">❯</span>
+			<span class="cmd">echo "© {today.getFullYear()} {SITE_TITLE} — all rights reserved"</span>
+		</div>
+		<div class="footer-meta">
+			<span class="muted mono">built with Astro · hosted on GitHub Pages</span>
+			<ul class="socials" aria-label="Social links">
+				{SOCIAL_LINKS.map((s) => (
+					<li>
+						<a
+							href={s.href}
+							target={s.icon === 'mail' ? undefined : '_blank'}
+							rel={s.icon === 'mail' ? undefined : 'noopener noreferrer'}
+							aria-label={s.label}
+							title={s.label}
+						>
+							<svg
+								xmlns="http://www.w3.org/2000/svg"
+								width="18"
+								height="18"
+								fill="currentColor"
+								viewBox={iconViewBoxes[s.icon]}
+								aria-hidden="true"
+							>
+								<path d={iconPaths[s.icon]}></path>
+							</svg>
+						</a>
+					</li>
+				))}
+			</ul>
+		</div>
 	</div>
 </footer>
+
 <style>
-	footer {
-		padding: 2em 1em 6em 1em;
-		background: linear-gradient(var(--gray-gradient)) no-repeat;
-		color: rgb(var(--gray));
-		text-align: center;
+	.site-footer {
+		margin-top: 4rem;
+		border-top: 1px solid var(--border);
+		background: var(--bg-elev);
+		color: var(--text-muted);
 	}
-	.social-links {
+	.footer-inner {
+		max-width: var(--max-page);
+		margin: 0 auto;
+		padding: 1.4rem 1.25rem 2rem;
 		display: flex;
-		justify-content: center;
-		gap: 1em;
-		margin-top: 1em;
+		flex-direction: column;
+		gap: 0.6rem;
 	}
-	.social-links a {
-		text-decoration: none;
-		color: rgb(var(--gray));
+	.footer-line {
+		font-family: var(--font-mono);
+		font-size: 0.92rem;
+		color: var(--text);
 	}
-	.social-links a:hover {
-		color: rgb(var(--gray-dark));
+	.prompt-glyph { color: var(--accent); margin-right: 0.4rem; }
+	.cmd { color: var(--text-muted); }
+	.footer-meta {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		gap: 1rem;
+		flex-wrap: wrap;
+	}
+	.socials {
+		list-style: none;
+		display: flex;
+		gap: 0.5rem;
+		padding: 0;
+		margin: 0;
+	}
+	.socials a {
+		display: inline-grid;
+		place-items: center;
+		width: 34px;
+		height: 34px;
+		color: var(--text-muted);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--surface);
+		transition: color 120ms ease, border-color 120ms ease, transform 120ms ease;
+	}
+	.socials a:hover {
+		color: var(--text);
+		border-color: var(--accent);
+		transform: translateY(-1px);
 	}
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,120 +1,199 @@
 ---
-import HeaderLink from "./HeaderLink.astro";
-import { SITE_TITLE } from "../consts";
+import HeaderLink from './HeaderLink.astro';
+import MvpBadge from './MvpBadge.astro';
+import { SITE_TITLE } from '../consts';
 ---
 
-<header>
-	<nav>
-		<h2><a href="/">{SITE_TITLE}</a></h2>
-		<div class="internal-links">
-<HeaderLink href="/">Home</HeaderLink>
-<HeaderLink href="/experience">Experience</HeaderLink>
-<HeaderLink href="/certifications">Certs</HeaderLink>
-<HeaderLink href="/speaking">Speaking</HeaderLink>
-<HeaderLink href="/blog">Blog</HeaderLink>
-		</div>
-		<div class="social-links">
-			<a href="https://x.com/snn_nr" target="_blank" title="Twitter/X">
-				<span class="sr-only">Sinan Nar on Twitter/X</span>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					fill="currentColor"
-					viewBox="0 0 1200 1227"
-					><path
-						d="M714 530.6 1156.6 0h-105L661.7 445.7 323.2 0H0l464.2 637.6L0 1227h105.1l412.2-476.2L876.8 1227H1200L714 530.6zm-145.2 167.7-47.7-66.2L87.6 80.7h180.2l292.7 406.1 47.7 66.2 441.5 617.1H869.5L576.8 684.5z"
-					></path></svg
-				>
-			</a>
-			<a href="mailto:sinan.nar@gmail.com" target="_blank" title="Email">
-				<span class="sr-only">Email Sinan Nar</span>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					fill="currentColor"
-					viewBox="0 0 16 16"
-					><path
-						d="M0 4a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H2a2 2 0 0 1-2-2V4zm2-1a1 1 0 0 0-1 1v.217l7 4.2 7-4.2V4a1 1 0 0 0-1-1H2zm13 2.383-4.708 2.825L15 11.118V5.383zM14.247 12H1.753l4.708-4.492 1.039.623a.5.5 0 0 0 .5 0l1.039-.623L14.247 12zM1 11.118l4.708-4.91L1 5.383v5.735z"
-					></path></svg
-				>
-			</a>
-			<a
-				href="https://github.com/sinannar"
-				target="_blank"
-				title="GitHub"
-			>
-				<span class="sr-only">Sinan Nar on GitHub</span>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					fill="currentColor"
-					viewBox="0 0 16 16"
-					><path
-						d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"
-					></path></svg
-				>
-			</a>
-			<a
-				href="https://linkedin.com/in/sinannar"
-				target="_blank"
-				title="LinkedIn"
-			>
-				<span class="sr-only">Sinan Nar on LinkedIn</span>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					width="24"
-					height="24"
-					fill="currentColor"
-					viewBox="0 0 16 16"
-					><path
-						d="M0 1.146C0 .513.526 0 1.175 0h13.65C15.474 0 16 .513 16 1.146v13.708c0 .633-.526 1.146-1.175 1.146H1.175C.526 16 0 15.487 0 14.854V1.146zm4.943 12.248V6.169H2.542v7.225h2.401zm-1.2-8.212c.837 0 1.358-.554 1.358-1.248-.015-.709-.521-1.248-1.342-1.248-.822 0-1.359.54-1.359 1.248 0 .694.521 1.248 1.327 1.248h.016zm4.908 8.212h2.4V9.359c0-.216.016-.432.08-.586.175-.432.574-.88 1.243-.88.877 0 1.228.664 1.228 1.637v4.864h2.4V9.25c0-2.22-1.184-3.252-2.764-3.252-1.274 0-1.845.7-2.165 1.193v.025h-.016a5.6 5.6 0 0 1 .016-.025V6.169h-2.4c.03.7 0 7.225 0 7.225z"
-					></path></svg
-				>
-			</a>
-		</div>
-	</nav>
-</header>
-<style>
-	header {
-		margin: 0;
-		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
-	}
-	h2 {
-		margin: 0;
-		font-size: 1em;
-	}
+<header class="site-header">
+	<div class="bar">
+		<a class="brand" href="/" aria-label={`${SITE_TITLE} — Home`}>
+			<span class="brand-prompt" aria-hidden="true">~/sinannar</span>
+			<span class="brand-sep" aria-hidden="true">$</span>
+			<span class="brand-name">{SITE_TITLE}</span>
+		</a>
 
-	h2 a,
-	h2 a.active {
-		text-decoration: none;
+		<MvpBadge variant="inline" />
+
+		<button
+			class="nav-toggle"
+			id="navToggle"
+			type="button"
+			aria-controls="primaryNav"
+			aria-expanded="false"
+			aria-label="Toggle navigation"
+		>
+			<span class="bar1" aria-hidden="true"></span>
+			<span class="bar2" aria-hidden="true"></span>
+			<span class="bar3" aria-hidden="true"></span>
+		</button>
+
+		<nav class="primary-nav" id="primaryNav" aria-label="Primary">
+			<HeaderLink href="/">home</HeaderLink>
+			<HeaderLink href="/experience">experience</HeaderLink>
+			<HeaderLink href="/certifications">certs</HeaderLink>
+			<HeaderLink href="/speaking">speaking</HeaderLink>
+			<HeaderLink href="/blog">blog</HeaderLink>
+		</nav>
+
+		<button
+			class="theme-toggle"
+			id="themeToggle"
+			type="button"
+			aria-label="Toggle color theme"
+			title="Toggle theme"
+		>
+			<svg class="icon-sun" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<circle cx="12" cy="12" r="4"></circle>
+				<path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"></path>
+			</svg>
+			<svg class="icon-moon" xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+				<path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
+			</svg>
+		</button>
+	</div>
+</header>
+
+<script is:inline>
+	(function () {
+		var root = document.documentElement;
+		var toggle = document.getElementById('themeToggle');
+		var nav = document.getElementById('primaryNav');
+		var navToggle = document.getElementById('navToggle');
+
+		function setTheme(t) {
+			root.setAttribute('data-theme', t);
+			try { localStorage.setItem('theme', t); } catch (_) {}
+		}
+		if (toggle) {
+			toggle.addEventListener('click', function () {
+				var current = root.getAttribute('data-theme') === 'light' ? 'dark' : 'light';
+				setTheme(current);
+			});
+		}
+		if (navToggle && nav) {
+			navToggle.addEventListener('click', function () {
+				var open = nav.classList.toggle('open');
+				navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+				navToggle.classList.toggle('open', open);
+			});
+		}
+	})();
+</script>
+
+<style>
+	.site-header {
+		position: sticky;
+		top: 0;
+		z-index: 50;
+		background: color-mix(in srgb, var(--bg) 88%, transparent);
+		backdrop-filter: saturate(140%) blur(10px);
+		-webkit-backdrop-filter: saturate(140%) blur(10px);
+		border-bottom: 1px solid var(--border);
 	}
-	nav {
+	.bar {
 		display: flex;
 		align-items: center;
-		justify-content: space-between;
+		gap: 1rem;
+		max-width: var(--max-page);
+		margin: 0 auto;
+		padding: 0.7rem 1.25rem;
 	}
-	nav a {
-		padding: 1em 0.5em;
-		color: var(--black);
-		border-bottom: 4px solid transparent;
+	.brand {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.45rem;
+		font-family: var(--font-mono);
+		color: var(--text);
 		text-decoration: none;
+		font-size: 0.95rem;
 	}
-	nav a.active {
-		text-decoration: none;
-		border-bottom-color: var(--accent);
-	}
-	.social-links,
-	.social-links a {
+	.brand:hover { text-decoration: none; }
+	.brand-prompt { color: var(--accent); }
+	.brand-sep { color: var(--prompt); }
+	.brand-name { color: var(--text); font-weight: 700; }
+
+	.primary-nav {
 		display: flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-left: auto;
 	}
-	@media (max-width: 720px) {
-		.social-links {
-			display: none;
+
+	.theme-toggle {
+		display: inline-grid;
+		place-items: center;
+		width: 36px;
+		height: 36px;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		color: var(--text-muted);
+		cursor: pointer;
+		transition: color 120ms ease, border-color 120ms ease;
+	}
+	.theme-toggle:hover { color: var(--text); border-color: var(--accent); }
+	.theme-toggle .icon-sun { display: none; }
+	.theme-toggle .icon-moon { display: block; }
+	:root[data-theme='light'] .theme-toggle .icon-sun { display: block; }
+	:root[data-theme='light'] .theme-toggle .icon-moon { display: none; }
+
+	.nav-toggle {
+		display: none;
+		flex-direction: column;
+		justify-content: center;
+		gap: 4px;
+		width: 36px;
+		height: 36px;
+		padding: 0;
+		margin-left: auto;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		cursor: pointer;
+	}
+	.nav-toggle span {
+		display: block;
+		width: 18px;
+		height: 2px;
+		background: var(--text);
+		margin: 0 auto;
+		border-radius: 2px;
+		transition: transform 150ms ease, opacity 150ms ease;
+	}
+	.nav-toggle.open .bar1 { transform: translateY(6px) rotate(45deg); }
+	.nav-toggle.open .bar2 { opacity: 0; }
+	.nav-toggle.open .bar3 { transform: translateY(-6px) rotate(-45deg); }
+
+	@media (max-width: 820px) {
+		.bar { gap: 0.6rem; flex-wrap: wrap; }
+		.nav-toggle { display: flex; }
+		.primary-nav {
+			order: 10;
+			width: 100%;
+			margin-left: 0;
+			flex-direction: column;
+			align-items: stretch;
+			gap: 0;
+			background: var(--surface);
+			border: 1px solid var(--border);
+			border-radius: var(--radius);
+			padding: 0.4rem;
+			max-height: 0;
+			overflow: hidden;
+			opacity: 0;
+			pointer-events: none;
+			transition: max-height 200ms ease, opacity 150ms ease, padding 200ms ease;
 		}
+		.primary-nav.open {
+			max-height: 360px;
+			opacity: 1;
+			pointer-events: auto;
+			padding: 0.4rem;
+			margin-top: 0.4rem;
+		}
+	}
+
+	@media (max-width: 480px) {
+		.brand-prompt { display: none; }
 	}
 </style>

--- a/src/components/HeaderLink.astro
+++ b/src/components/HeaderLink.astro
@@ -9,16 +9,46 @@ const subpath = pathname.match(/[^\/]+/g);
 const isActive = href === pathname || href === '/' + (subpath?.[0] || '');
 ---
 
-<a href={href} class:list={[className, { active: isActive }]} {...props}>
+<a href={href} class:list={[className, { active: isActive }]} aria-current={isActive ? 'page' : undefined} {...props}>
+	<span class="hl-marker" aria-hidden="true">❯</span>
 	<slot />
 </a>
 <style>
 	a {
-		display: inline-block;
+		position: relative;
+		display: inline-flex;
+		align-items: center;
+		gap: 0.3rem;
+		padding: 0.35rem 0.55rem;
+		font-family: var(--font-mono);
+		font-size: 0.92rem;
+		color: var(--text-muted);
+		text-decoration: none;
+		border-radius: var(--radius-sm);
+		transition: color 120ms ease, background 120ms ease;
+	}
+	a .hl-marker {
+		opacity: 0;
+		color: var(--prompt);
+		transition: opacity 120ms ease, transform 120ms ease;
+		transform: translateX(-2px);
+	}
+	a:hover {
+		color: var(--text);
+		background: var(--surface-2);
 		text-decoration: none;
 	}
+	a:hover .hl-marker {
+		opacity: 1;
+		transform: translateX(0);
+	}
 	a.active {
-		font-weight: bolder;
-		text-decoration: underline;
+		color: var(--text);
+		background: var(--surface-2);
+	}
+	a.active .hl-marker {
+		opacity: 1;
+		color: var(--accent);
+		transform: translateX(0);
 	}
 </style>

--- a/src/components/MvpBadge.astro
+++ b/src/components/MvpBadge.astro
@@ -1,0 +1,62 @@
+---
+import { MVP_URL, MVP_LABEL } from '../consts';
+
+interface Props {
+	variant?: 'inline' | 'block';
+	label?: string;
+}
+
+const { variant = 'inline', label = MVP_LABEL } = Astro.props;
+---
+
+{variant === 'inline' ? (
+	<a class="chip mvp" href={MVP_URL} target="_blank" rel="noopener noreferrer" title="View MVP profile">
+		<span class="dot" aria-hidden="true"></span>
+		{label}
+	</a>
+) : (
+	<a class="mvp-block" href={MVP_URL} target="_blank" rel="noopener noreferrer">
+		<span class="mvp-glyph" aria-hidden="true">★</span>
+		<span class="mvp-text">
+			<span class="mvp-title">Microsoft MVP</span>
+			<span class="mvp-sub">Developer Technologies · 2026</span>
+		</span>
+		<span class="mvp-arrow" aria-hidden="true">→</span>
+	</a>
+)}
+
+<style>
+	.mvp-block {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.85rem;
+		padding: 0.7rem 1rem;
+		background: var(--mvp-soft);
+		border: 1px solid var(--mvp);
+		border-radius: var(--radius);
+		color: var(--text);
+		text-decoration: none;
+		font-family: var(--font-mono);
+		transition: transform 120ms ease, box-shadow 120ms ease;
+	}
+	.mvp-block:hover {
+		transform: translateY(-1px);
+		box-shadow: 0 0 0 1px var(--mvp), 0 0 24px var(--mvp-soft);
+		text-decoration: none;
+	}
+	.mvp-glyph {
+		display: grid;
+		place-items: center;
+		width: 2rem;
+		height: 2rem;
+		border-radius: 999px;
+		background: var(--mvp);
+		color: var(--bg);
+		font-size: 1rem;
+	}
+	.mvp-text { display: flex; flex-direction: column; line-height: 1.2; }
+	.mvp-title { font-weight: 700; color: var(--mvp); }
+	.mvp-sub { font-size: 0.78rem; color: var(--text-muted); }
+	.mvp-arrow { color: var(--mvp); transition: transform 120ms ease; }
+	.mvp-block:hover .mvp-arrow { transform: translateX(3px); }
+</style>

--- a/src/components/TerminalWindow.astro
+++ b/src/components/TerminalWindow.astro
@@ -1,0 +1,36 @@
+---
+interface Props {
+	title?: string;
+	prompt?: string;
+	class?: string;
+}
+
+const { title, prompt, class: className } = Astro.props;
+---
+
+<section class:list={["terminal", className]}>
+	<header class="terminal-bar">
+		<span class="terminal-dots" aria-hidden="true">
+			<span class="terminal-dot red"></span>
+			<span class="terminal-dot yellow"></span>
+			<span class="terminal-dot green"></span>
+		</span>
+		{title && <span class="terminal-bar-title">{title}</span>}
+	</header>
+	<div class="terminal-body">
+		{prompt && <p class="terminal-prompt"><span class="prompt">{prompt}</span></p>}
+		<slot />
+	</div>
+</section>
+
+<style>
+	.terminal-bar-title {
+		flex: 1;
+		text-align: center;
+		color: var(--text-muted);
+	}
+	.terminal-prompt {
+		margin: 0 0 1rem;
+		font-size: 0.95rem;
+	}
+</style>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -2,4 +2,17 @@
 // You can import this data from anywhere in your site by using the `import` keyword.
 
 export const SITE_TITLE = 'Sinan Nar';
-export const SITE_DESCRIPTION = 'Welcome to my website!';
+export const SITE_DESCRIPTION =
+	'Sinan Nar — Microsoft MVP, Senior Software Engineer, .NET / Azure / GitHub. Notes, talks, and tinkering from Auckland.';
+export const SITE_AUTHOR = 'Sinan Nar';
+export const SITE_TAGLINE = 'Senior Software Engineer · Microsoft MVP';
+export const MVP_URL =
+	'https://mvp.microsoft.com/en-US/mvp/profile/43c0eda5-4a49-485b-8878-1f7ca51bb0a9';
+export const MVP_LABEL = 'Microsoft MVP';
+
+export const SOCIAL_LINKS = [
+	{ label: 'Twitter/X', href: 'https://x.com/snn_nr', handle: '@snn_nr', icon: 'x' },
+	{ label: 'GitHub', href: 'https://github.com/sinannar', handle: 'sinannar', icon: 'github' },
+	{ label: 'LinkedIn', href: 'https://linkedin.com/in/sinannar', handle: 'sinannar', icon: 'linkedin' },
+	{ label: 'Email', href: 'mailto:sinan.nar@gmail.com', handle: 'sinan.nar@gmail.com', icon: 'mail' },
+] as const;

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -21,101 +21,38 @@ const toc = headings.filter((heading) => heading.depth === 2 || heading.depth ==
 
 <html lang="en">
 	<head>
-		<BaseHead title={title} description={description} />
-		<style>
-			main {
-				width: calc(100% - 2em);
-				max-width: 100%;
-				margin: 0;
-			}
-			.hero-image {
-				width: 100%;
-			}
-			.hero-image img {
-				display: block;
-				margin: 0 auto;
-				border-radius: 12px;
-				box-shadow: var(--box-shadow);
-			}
-			.prose {
-				width: 720px;
-				max-width: calc(100% - 2em);
-				margin: auto;
-				padding: 1em;
-				color: rgb(var(--gray-dark));
-			}
-			.title {
-				margin-bottom: 1em;
-				padding: 1em 0;
-				text-align: center;
-				line-height: 1;
-			}
-			.title h1 {
-				margin: 0 0 0.5em 0;
-			}
-			.date {
-				margin-bottom: 0.5em;
-				color: rgb(var(--gray));
-			}
-			.last-updated-on {
-				font-style: italic;
-			}
-			.toc {
-				margin: 0 0 2.5rem;
-				padding: 1rem 1.25rem;
-				border: 1px solid rgb(var(--gray-light));
-				border-radius: 10px;
-				background: rgba(var(--gray-light), 0.3);
-			}
-			.toc-title {
-				margin: 0 0 0.75rem;
-				font-size: 1rem;
-				font-weight: 700;
-			}
-			.toc-list {
-				margin: 0;
-				padding-left: 1.25rem;
-			}
-			.toc-list li {
-				margin: 0.3rem 0;
-			}
-			.toc-list .toc-depth-3 {
-				margin-left: 1rem;
-			}
-			@media (max-width: 720px) {
-				.toc {
-					padding: 0.9rem 1rem;
-				}
-			}
-		</style>
+		<BaseHead title={title} description={description} image={heroImage} />
 	</head>
-
 	<body>
 		<Header />
-		<main>
+		<main class="post-main">
 			<article>
-				<div class="hero-image">
-					{heroImage && <img src={heroImage} alt="" />}
-				</div>
-				<div class="prose">
-					<div class="title">
-						<div class="date">
-							<FormattedDate date={pubDate} />
-							{
-								updatedDate && (
-									<div class="last-updated-on">
-										Last updated on <FormattedDate date={updatedDate} />
-									</div>
-								)
-							}
-						</div>
-						<h1>{title}</h1>
-						<hr />
+				<header class="post-header">
+					<p class="eyebrow">
+						<a href="/blog">~/blog</a> <span class="muted">/ </span>
+						<FormattedDate date={pubDate} />
+						{updatedDate && (
+							<>
+								<span class="muted"> · updated </span>
+								<FormattedDate date={updatedDate} />
+							</>
+						)}
+					</p>
+					<h1 class="post-title">{title}</h1>
+					{description && <p class="post-desc">{description}</p>}
+				</header>
+
+				{heroImage && (
+					<div class="hero">
+						<img src={heroImage} alt="" />
 					</div>
-					{
-						toc.length > 0 && (
-							<nav class="toc" aria-label="Table of contents">
-								<p class="toc-title">Table of contents</p>
+				)}
+
+				<div class="post-layout">
+					{toc.length > 0 && (
+						<aside class="toc-wrapper" aria-label="Table of contents">
+							<nav class="toc">
+								<p class="toc-title mono">On this page</p>
 								<ol class="toc-list">
 									{toc.map((heading) => (
 										<li class={heading.depth === 3 ? 'toc-depth-3' : undefined}>
@@ -124,12 +61,93 @@ const toc = headings.filter((heading) => heading.depth === 2 || heading.depth ==
 									))}
 								</ol>
 							</nav>
-						)
-					}
-					<slot />
+						</aside>
+					)}
+					<div class="prose">
+						<slot />
+					</div>
 				</div>
 			</article>
 		</main>
 		<Footer />
 	</body>
 </html>
+
+<style>
+	.post-main { max-width: var(--max-page); }
+	.post-header {
+		max-width: var(--max-content);
+		margin: 0 auto 1.5rem;
+	}
+	.post-header .eyebrow a { color: var(--accent); }
+	.post-title {
+		margin: 0.25em 0 0.5em;
+		font-size: clamp(1.8rem, 2.2vw + 1rem, 2.4rem);
+	}
+	.post-desc {
+		color: var(--text-muted);
+		font-size: 1.1rem;
+		margin: 0;
+	}
+	.hero {
+		max-width: var(--max-page);
+		margin: 1rem auto 2rem;
+	}
+	.hero img {
+		width: 100%;
+		max-height: 420px;
+		object-fit: cover;
+		border-radius: var(--radius-lg);
+		border: 1px solid var(--border);
+		box-shadow: var(--shadow-1);
+	}
+
+	.post-layout {
+		display: grid;
+		grid-template-columns: 240px minmax(0, var(--max-content));
+		gap: 2rem;
+		justify-content: center;
+		align-items: start;
+	}
+	.post-layout:has(.prose:only-child),
+	.post-layout:not(:has(.toc-wrapper)) {
+		grid-template-columns: minmax(0, var(--max-content));
+	}
+
+	.toc-wrapper { position: sticky; top: 88px; }
+	.toc {
+		padding: 1rem 1.1rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+	}
+	.toc-title {
+		margin: 0 0 0.6rem;
+		font-size: 0.78rem;
+		text-transform: uppercase;
+		letter-spacing: 0.1em;
+		color: var(--text-muted);
+	}
+	.toc-list {
+		margin: 0;
+		padding-left: 1.1rem;
+		font-size: 0.9rem;
+	}
+	.toc-list li { margin: 0.3rem 0; }
+	.toc-list a { color: var(--text-muted); }
+	.toc-list a:hover { color: var(--accent); }
+	.toc-list .toc-depth-3 { margin-left: 0.9rem; }
+
+	.prose { width: 100%; }
+
+	@media (max-width: 980px) {
+		.post-layout {
+			grid-template-columns: minmax(0, var(--max-content));
+		}
+		.toc-wrapper {
+			position: static;
+			order: -1;
+		}
+		.toc { margin-bottom: 1rem; }
+	}
+</style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -1,62 +1,78 @@
 ---
-import Layout from '../layouts/BlogPost.astro';
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import TerminalWindow from '../components/TerminalWindow.astro';
+import MvpBadge from '../components/MvpBadge.astro';
+import { SITE_TITLE, SOCIAL_LINKS } from '../consts';
 ---
 
-<Layout
-	title="About Me"
-	description="Lorem ipsum dolor sit amet"
-	pubDate={new Date('August 08 2021')}
-	heroImage="/blog-placeholder-about.jpg"
->
-	<p>
-		Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut
-		labore et dolore magna aliqua. Vitae ultricies leo integer malesuada nunc vel risus commodo
-		viverra. Adipiscing enim eu turpis egestas pretium. Euismod elementum nisi quis eleifend quam
-		adipiscing. In hac habitasse platea dictumst vestibulum. Sagittis purus sit amet volutpat. Netus
-		et malesuada fames ac turpis egestas. Eget magna fermentum iaculis eu non diam phasellus
-		vestibulum lorem. Varius sit amet mattis vulputate enim. Habitasse platea dictumst quisque
-		sagittis. Integer quis auctor elit sed vulputate mi. Dictumst quisque sagittis purus sit amet.
-	</p>
+<!doctype html>
+<html lang="en">
+	<head>
+		<BaseHead title={`About | ${SITE_TITLE}`} description="About Sinan Nar — Microsoft MVP, Senior Software Engineer based in Auckland, New Zealand." />
+	</head>
+	<body>
+		<Header />
+		<main>
+			<section class="section">
+				<p class="eyebrow">~/about.md $ cat ./bio</p>
+				<TerminalWindow title="about.md">
+					<h1>About me</h1>
+					<p>
+						I'm Sinan — a software engineer based in Auckland, New Zealand, working as a consultant at
+						<a href="https://arinco.com.au" target="_blank" rel="noopener">ARINCO</a>, a Microsoft and GitHub
+						partner consultancy. I focus on building apps and AI-enabled systems on the Microsoft stack:
+						.NET, Azure, and GitHub.
+					</p>
+					<p>
+						I co-organise three community groups in Aotearoa: the
+						<a href="https://www.meetup.com/auckland-azure-usergroup/" target="_blank" rel="noopener">Aotearoa Azure Meetup</a>,
+						the <a href="https://www.meetup.com/akl-net/" target="_blank" rel="noopener">Auckland .NET User Group</a>,
+						and the <a href="https://www.meetup.com/aotearoa-nz-github-user-group/" target="_blank" rel="noopener">Aotearoa NZ GitHub User Group</a>.
+						I speak regularly at meetups and conferences across the region.
+					</p>
+					<p>
+						This blog is where I share what I'm learning — distributed systems with .NET Aspire,
+						Copilot and the GitHub Copilot SDK, Azure platform engineering, and the kind of pragmatic
+						engineering practices that make teams ship.
+					</p>
 
-	<p>
-		Morbi tristique senectus et netus. Id semper risus in hendrerit gravida rutrum quisque non
-		tellus. Habitasse platea dictumst quisque sagittis purus sit amet. Tellus molestie nunc non
-		blandit massa. Cursus vitae congue mauris rhoncus. Accumsan tortor posuere ac ut. Fringilla urna
-		porttitor rhoncus dolor. Elit ullamcorper dignissim cras tincidunt lobortis. In cursus turpis
-		massa tincidunt dui ut ornare lectus. Integer feugiat scelerisque varius morbi enim nunc.
-		Bibendum neque egestas congue quisque egestas diam. Cras ornare arcu dui vivamus arcu felis
-		bibendum. Dignissim suspendisse in est ante in nibh mauris. Sed tempus urna et pharetra pharetra
-		massa massa ultricies mi.
-	</p>
+					<div class="mvp-block-wrap">
+						<MvpBadge variant="block" />
+					</div>
+				</TerminalWindow>
+			</section>
 
-	<p>
-		Mollis nunc sed id semper risus in. Convallis a cras semper auctor neque. Diam sit amet nisl
-		suscipit. Lacus viverra vitae congue eu consequat ac felis donec. Egestas integer eget aliquet
-		nibh praesent tristique magna sit amet. Eget magna fermentum iaculis eu non diam. In vitae
-		turpis massa sed elementum. Tristique et egestas quis ipsum suspendisse ultrices. Eget lorem
-		dolor sed viverra ipsum. Vel turpis nunc eget lorem dolor sed viverra. Posuere ac ut consequat
-		semper viverra nam. Laoreet suspendisse interdum consectetur libero id faucibus. Diam phasellus
-		vestibulum lorem sed risus ultricies tristique. Rhoncus dolor purus non enim praesent elementum
-		facilisis. Ultrices tincidunt arcu non sodales neque. Tempus egestas sed sed risus pretium quam
-		vulputate. Viverra suspendisse potenti nullam ac tortor vitae purus faucibus ornare. Fringilla
-		urna porttitor rhoncus dolor purus non. Amet dictum sit amet justo donec enim.
-	</p>
+			<section class="section">
+				<p class="eyebrow">~/about $ ls ./contact</p>
+				<TerminalWindow title="contact">
+					<ul class="contact-list">
+						{SOCIAL_LINKS.map((s) => (
+							<li>
+								<span class="key mono">{s.label.toLowerCase()}</span>
+								<a href={s.href} target={s.icon === 'mail' ? undefined : '_blank'} rel="noopener noreferrer">{s.handle}</a>
+							</li>
+						))}
+					</ul>
+				</TerminalWindow>
+			</section>
+		</main>
+		<Footer />
+	</body>
+</html>
 
-	<p>
-		Mattis ullamcorper velit sed ullamcorper morbi tincidunt. Tortor posuere ac ut consequat semper
-		viverra. Tellus mauris a diam maecenas sed enim ut sem viverra. Venenatis urna cursus eget nunc
-		scelerisque viverra mauris in. Arcu ac tortor dignissim convallis aenean et tortor at. Curabitur
-		gravida arcu ac tortor dignissim convallis aenean et tortor. Egestas tellus rutrum tellus
-		pellentesque eu. Fusce ut placerat orci nulla pellentesque dignissim enim sit amet. Ut enim
-		blandit volutpat maecenas volutpat blandit aliquam etiam. Id donec ultrices tincidunt arcu. Id
-		cursus metus aliquam eleifend mi.
-	</p>
-
-	<p>
-		Tempus quam pellentesque nec nam aliquam sem. Risus at ultrices mi tempus imperdiet. Id porta
-		nibh venenatis cras sed felis eget velit. Ipsum a arcu cursus vitae. Facilisis magna etiam
-		tempor orci eu lobortis elementum. Tincidunt dui ut ornare lectus sit. Quisque non tellus orci
-		ac. Blandit libero volutpat sed cras. Nec tincidunt praesent semper feugiat nibh sed pulvinar
-		proin gravida. Egestas integer eget aliquet nibh praesent tristique magna.
-	</p>
-</Layout>
+<style>
+	.mvp-block-wrap { margin: 1.25rem 0 0.25rem; }
+	.contact-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: max-content 1fr;
+		gap: 0.5rem 1.25rem;
+		font-family: var(--font-mono);
+	}
+	.contact-list .key { color: var(--prompt); }
+	.contact-list .key::after { content: ':'; color: var(--text-muted); margin-left: 0.1rem; }
+</style>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -6,104 +6,133 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../../components/FormattedDate.astro';
 
-const posts = (await getCollection('blog')).sort(
-	(a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
-);
+const posts = (await getCollection('blog'))
+	.filter((p) => !p.id.startsWith('unused/'))
+	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 
 <!doctype html>
 <html lang="en">
 	<head>
-		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-		<style>
-			main {
-				width: 960px;
-			}
-			ul {
-				display: flex;
-				flex-wrap: wrap;
-				gap: 2rem;
-				list-style-type: none;
-				margin: 0;
-				padding: 0;
-			}
-			ul li {
-				width: calc(50% - 1rem);
-			}
-			ul li * {
-				text-decoration: none;
-				transition: 0.2s ease;
-			}
-			ul li:first-child {
-				width: 100%;
-				margin-bottom: 1rem;
-				text-align: center;
-			}
-			
-			ul li:first-child .title {
-				font-size: 2.369rem;
-			}
-			ul li img {
-				margin-bottom: 0.5rem;
-				border-radius: 12px;
-			}
-			ul li a {
-				display: block;
-			}
-			.title {
-				margin: 0;
-				color: rgb(var(--black));
-				line-height: 1;
-			}
-			.date {
-				margin: 0;
-				color: rgb(var(--gray));
-			}
-			ul li a:hover h4,
-			ul li a:hover .date {
-				color: rgb(var(--accent));
-			}
-			ul a:hover img {
-				box-shadow: var(--box-shadow);
-			}
-			@media (max-width: 720px) {
-				ul {
-					gap: 0.5em;
-				}
-				ul li {
-					width: 100%;
-					text-align: center;
-				}
-				ul li:first-child {
-					margin-bottom: 0;
-				}
-				ul li:first-child .title {
-					font-size: 1.563em;
-				}
-			}
-		</style>
+		<BaseHead title={`Blog | ${SITE_TITLE}`} description={SITE_DESCRIPTION} />
 	</head>
 	<body>
 		<Header />
 		<main>
-			<section>
-				<ul>
-					{
-						posts.map((post) => (
-							<li>
-								<a href={`/blog/${post.id}/`}>
-									<img src={post.data.heroImage} alt="" />
-									<h4 class="title">{post.data.title}</h4>
-									<p class="date">
-										<FormattedDate date={post.data.pubDate} />
-									</p>
-								</a>
-							</li>
-						))
-					}
+			<section class="section">
+				<p class="eyebrow">~/blog $ ls -lt</p>
+				<h1>Blog</h1>
+				<p class="muted">Notes on .NET, Azure, GitHub, and the bits in between.</p>
+			</section>
+
+			<section class="section">
+				<ul class="posts">
+					{posts.map((post) => (
+						<li>
+							<a class="post-card" href={`/blog/${post.id}/`}>
+								<article class="card">
+									<header class="card-bar">
+										<span class="dots" aria-hidden="true">
+											<span class="d red"></span><span class="d yellow"></span><span class="d green"></span>
+										</span>
+										<span class="card-bar-title mono">{post.id}.md</span>
+									</header>
+									{post.data.heroImage && (
+										<div class="thumb">
+											<img src={post.data.heroImage} alt="" loading="lazy" />
+										</div>
+									)}
+									<div class="card-body">
+										<h2 class="title">{post.data.title}</h2>
+										<p class="desc">{post.data.description}</p>
+										<p class="meta mono">
+											<span class="prompt-glyph" aria-hidden="true">❯</span>
+											<FormattedDate date={post.data.pubDate} />
+										</p>
+									</div>
+								</article>
+							</a>
+						</li>
+					))}
 				</ul>
 			</section>
 		</main>
 		<Footer />
 	</body>
 </html>
+
+<style>
+	.posts {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 1.25rem;
+	}
+	.posts > li:first-child { grid-column: 1 / -1; }
+	.posts > li:first-child .thumb { aspect-ratio: 21 / 9; }
+	.posts > li:first-child .title { font-size: 1.55rem; }
+	@media (max-width: 720px) {
+		.posts { grid-template-columns: 1fr; }
+		.posts > li:first-child .thumb { aspect-ratio: 16 / 9; }
+	}
+
+	.post-card { display: block; text-decoration: none; color: inherit; }
+	.post-card:hover { text-decoration: none; }
+
+	.card {
+		display: flex;
+		flex-direction: column;
+		height: 100%;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		overflow: hidden;
+		transition: transform 120ms ease, border-color 120ms ease, box-shadow 120ms ease;
+	}
+	.post-card:hover .card {
+		transform: translateY(-2px);
+		border-color: var(--accent);
+		box-shadow: var(--shadow-2);
+	}
+	.card-bar {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		padding: 0.5rem 0.75rem;
+		background: var(--surface-2);
+		border-bottom: 1px solid var(--border);
+		font-size: 0.78rem;
+		color: var(--text-muted);
+	}
+	.dots { display: inline-flex; gap: 6px; }
+	.d { width: 10px; height: 10px; border-radius: 999px; background: var(--border-strong); }
+	.d.red { background: #ff5f57; } .d.yellow { background: #febc2e; } .d.green { background: #28c840; }
+	.card-bar-title { flex: 1; text-align: center; color: var(--text-muted); }
+
+	.thumb {
+		aspect-ratio: 16 / 9;
+		overflow: hidden;
+		background: var(--surface-2);
+	}
+	.thumb img {
+		width: 100%;
+		height: 100%;
+		object-fit: cover;
+		border-radius: 0;
+		transition: transform 220ms ease;
+	}
+	.post-card:hover .thumb img { transform: scale(1.03); }
+
+	.card-body { padding: 1rem 1.1rem 1.15rem; display: flex; flex-direction: column; gap: 0.5rem; }
+	.title {
+		margin: 0;
+		font-size: 1.2rem;
+		color: var(--text);
+		line-height: 1.3;
+	}
+	.desc { margin: 0; color: var(--text-muted); font-size: 0.95rem; line-height: 1.55; }
+	.meta { margin: 0; font-size: 0.82rem; color: var(--text-muted); }
+	.prompt-glyph { color: var(--accent); margin-right: 0.4rem; }
+</style>

--- a/src/pages/certifications.astro
+++ b/src/pages/certifications.astro
@@ -2,76 +2,106 @@
 import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
+import MvpBadge from '../components/MvpBadge.astro';
 import { SITE_TITLE } from '../consts';
+
+interface Cert {
+	name: string;
+	issued: string;
+	image: string;
+	fallback?: string;
+}
+
+const certs: Cert[] = [
+	{ name: 'Microsoft Certified: AI Fundamentals', issued: 'June 2025', image: '/certifications/microsoft-certified-fundamentals-badge.svg', fallback: '/blog-placeholder-2.jpg' },
+	{ name: 'GitHub Copilot', issued: 'May 2025', image: '/certifications/githubcopilot.png', fallback: '/blog-placeholder-2.jpg' },
+	{ name: 'MongoDB Associate Developer', issued: 'Nov 2024', image: '/certifications/mongocert.png', fallback: '/blog-placeholder-2.jpg' },
+	{ name: 'Microsoft Certified: Azure AI Engineer Associate', issued: 'Jun 2024', image: '/certifications/microsoft-certified-associate-badge.svg', fallback: '/blog-placeholder-1.jpg' },
+	{ name: 'Microsoft Certified: Azure Solutions Architect Expert', issued: 'Mar 2023', image: '/certifications/microsoft-certified-azure-solutions-architect-expert.png' },
+	{ name: 'Microsoft Certified: DevOps Engineer Expert', issued: 'Dec 2022', image: '/certifications/microsoft-certified-devops-engineer-expert.png' },
+	{ name: 'Microsoft Certified: Azure Developer Associate', issued: 'Mar 2022', image: '/certifications/microsoft-certified-azure-developer-associate.1.png' },
+	{ name: 'Microsoft Certified: Azure Administrator Associate', issued: 'Feb 2022', image: '/certifications/microsoft-certified-azure-administrator-associate.2.png' },
+	{ name: 'Microsoft Certified: Azure Fundamentals', issued: 'Jul 2020', image: '/certifications/microsoft-certified-azure-fundamentals.png' },
+	{ name: 'Microsoft Certified Solutions Developer: App Builder', issued: 'Aug 2019', image: '/certifications/mcsd-app-builder-certified-2019.png' },
+	{ name: 'Microsoft Certified Solutions Associate: Web Applications', issued: 'Mar 2019', image: '/certifications/mcsa-web-applications-certified-2019.png' },
+	{ name: 'Microsoft Certified Professional', issued: 'Sep 2018', image: '/certifications/microsoft-certified-general-badge.svg', fallback: '/blog-placeholder-3.jpg' },
+];
 ---
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <BaseHead title={`Certifications | ${SITE_TITLE}`} description="Certifications of Sinan Nar" />
-  </head>
-  <body>
-    <Header />
-    <main>
-      <section style="max-width:700px;margin:2rem auto 2rem auto;">
-        <h1 style="font-size:2rem; margin-bottom:1.5rem;">Certifications</h1>
-        <ul style="font-size:1.1rem;line-height:2.2;list-style:none;padding:0;">
+	<head>
+		<BaseHead title={`Certifications | ${SITE_TITLE}`} description="Certifications and awards held by Sinan Nar." />
+	</head>
+	<body>
+		<Header />
+		<main>
+			<section class="section">
+				<p class="eyebrow">~/certifications $ ls -1</p>
+				<h1>Certifications &amp; awards</h1>
+				<p class="muted">Microsoft, GitHub, MongoDB — and a Microsoft MVP recognition I'm proud of.</p>
+			</section>
 
+			<section class="section">
+				<p class="eyebrow">~/awards $ cat ./mvp.json</p>
+				<MvpBadge variant="block" />
+			</section>
 
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-fundamentals-badge.svg" alt="Microsoft Certified: AI Fundamentals" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" onerror="this.onerror=null;this.src='/blog-placeholder-2.jpg';" />
-            <span><strong>Microsoft Certified: AI Fundamentals</strong> <span style="color:#888;">— June 2025</span></span>
-          </li>
-
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/githubcopilot.png" alt="GitHub Copilot" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" onerror="this.onerror=null;this.src='/blog-placeholder-2.jpg';" />
-            <span><strong>GitHub Copilot</strong> <span style="color:#888;">— May 2025</span></span>
-          </li>
-
-
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/mongocert.png" alt="MongoDB Associate Developer" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" onerror="this.onerror=null;this.src='/blog-placeholder-2.jpg';" />
-            <span><strong>MongoDB Associate Developer</strong> <span style="color:#888;">— Nov 2024</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-associate-badge.svg" alt="Azure AI Engineer Associate" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" onerror="this.onerror=null;this.src='/blog-placeholder-1.jpg';" />
-            <span><strong>Microsoft Certified: Azure AI Engineer Associate</strong> <span style="color:#888;">— Jun 2024</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-azure-solutions-architect-expert.png" alt="Azure Solutions Architect Expert" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified: Azure Solution Architect Expert</strong> <span style="color:#888;">— Mar 2023</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-devops-engineer-expert.png" alt="DevOps Engineer Expert" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified: DevOps Engineer Expert</strong> <span style="color:#888;">— Dec 2022</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-azure-developer-associate.1.png" alt="Azure Developer Associate" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified: Azure Developer Associate</strong> <span style="color:#888;">— Mar 2022</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-azure-administrator-associate.2.png" alt="Azure Administrator Associate" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified: Azure Administrator Associate</strong> <span style="color:#888;">— Feb 2022</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-azure-fundamentals.png" alt="Azure Fundamentals" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified: Azure Fundamentals</strong> <span style="color:#888;">— Jul 2020</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/mcsd-app-builder-certified-2019.png" alt="MCSD App Builder" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified Solutions Developer: App Builder</strong> <span style="color:#888;">— Aug 2019</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/mcsa-web-applications-certified-2019.png" alt="MCSA Web Applications" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" />
-            <span><strong>Microsoft Certified Solutions Associate: Web Applications</strong> <span style="color:#888;">— Mar 2019</span></span>
-          </li>
-          <li style="display:flex;align-items:center;gap:0.7em;margin-bottom:0.7em;">
-            <img src="/certifications/microsoft-certified-general-badge.svg" alt="Microsoft Certified Professional" style="height:48px;width:auto;border-radius:6px;box-shadow:0 1px 4px #0001;" onerror="this.onerror=null;this.src='/blog-placeholder-3.jpg';" />
-            <span><strong>Microsoft Certified Professional</strong> <span style="color:#888;">— Sep 2018</span></span>
-          </li>
-        </ul>
-      </section>
-    </main>
-    <Footer />
-  </body>
+			<section class="section">
+				<p class="eyebrow">~/certifications $ tree</p>
+				<ul class="cert-grid">
+					{certs.map((cert) => (
+						<li class="cert">
+							<img
+								src={cert.image}
+								alt={cert.name}
+								loading="lazy"
+								onerror={cert.fallback ? `this.onerror=null;this.src='${cert.fallback}';` : undefined}
+							/>
+							<div>
+								<strong>{cert.name}</strong>
+								<span class="issued mono">{cert.issued}</span>
+							</div>
+						</li>
+					))}
+				</ul>
+			</section>
+		</main>
+		<Footer />
+	</body>
 </html>
+
+<style>
+	.cert-grid {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: grid;
+		grid-template-columns: repeat(2, minmax(0, 1fr));
+		gap: 0.85rem;
+	}
+	@media (max-width: 640px) { .cert-grid { grid-template-columns: 1fr; } }
+
+	.cert {
+		display: flex;
+		align-items: center;
+		gap: 0.85rem;
+		padding: 0.7rem 0.85rem;
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		transition: border-color 120ms ease, transform 120ms ease;
+	}
+	.cert:hover { border-color: var(--accent); transform: translateY(-1px); }
+	.cert img {
+		width: 48px;
+		height: 48px;
+		object-fit: contain;
+		border-radius: var(--radius-sm);
+		background: var(--surface-2);
+		padding: 4px;
+		border: 1px solid var(--border);
+	}
+	.cert strong { display: block; line-height: 1.25; }
+	.issued { color: var(--text-muted); font-size: 0.82rem; }
+</style>

--- a/src/pages/experience.astro
+++ b/src/pages/experience.astro
@@ -3,214 +3,271 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { SITE_TITLE } from '../consts';
+
+interface Role {
+	title: string;
+	company: string;
+	location: string;
+	from: string;
+	to: string;
+	current?: boolean;
+	highlights: string[];
+	projects?: { name: string; detail?: string }[];
+}
+
+const roles: Role[] = [
+	{
+		title: 'Consultant',
+		company: 'ARINCO',
+		location: 'Auckland',
+		from: 'Jun 2025',
+		to: 'Present',
+		current: true,
+		highlights: [],
+		projects: [
+			{ name: 'MCC', detail: 'AI assistant integration' },
+			{ name: 'Smart Group', detail: 'Integration modernisation' },
+			{ name: 'FMA', detail: 'AI Accelerator' },
+			{ name: 'Beaumont Tiles', detail: 'Azure DevOps' },
+			{ name: 'CSR', detail: 'Identity migration' },
+		],
+	},
+	{
+		title: 'Senior Software Engineer',
+		company: 'EROAD',
+		location: 'Auckland',
+		from: 'Aug 2023',
+		to: 'May 2025',
+		highlights: [
+			'Architected event-driven customer integrations using Kafka and Service Bus.',
+			'Optimised CI/CD pipelines and reduced deployment failures.',
+			'Improved DX through Clean Code, SOLID, and engineering best practices.',
+			'Designed microservices using Clean Architecture, DDD, and Kubernetes.',
+			'Enhanced observability with Datadog dashboards and alerting.',
+			'Led adoption of feature flags via Azure App Configuration.',
+			'Migrated "click-ops" infrastructure to Terraform.',
+			'Drove architecture reviews and supported hiring/interviews.',
+		],
+		projects: [
+			{ name: 'Sysco Integration', detail: '.NET 6, Kubernetes, ServiceBus, GitHub Actions, Kafka, MongoDB, Datadog' },
+			{ name: 'Customer Integrations', detail: '.NET Core 3.1, Kubernetes, Azure DevOps, ServiceBus, MongoDB, MediatR' },
+			{ name: 'Legacy Pipeline Modernization', detail: '.NET, Bitbucket, Azure Functions, Azure DevOps' },
+		],
+	},
+	{
+		title: 'Lead Software Engineer',
+		company: 'First Rescue',
+		location: 'Auckland',
+		from: 'Jul 2019',
+		to: 'Aug 2023',
+		highlights: [
+			'Led development of scalable .NET Core & Angular applications.',
+			'Migrated legacy SQL databases to Azure with compliance and security improvements.',
+			'Rewrote incident & policy management systems for better scalability.',
+			'Maintained a Xamarin-based mobile application.',
+			'Integrated ServiceNow, Auto Integrity, and Linksoft.',
+			'Built and tuned CI/CD pipelines in Azure DevOps.',
+		],
+		projects: [
+			{ name: 'Incident Management', detail: '.NET Core, Angular, Azure DevOps' },
+			{ name: 'Policy Management', detail: '.NET Core, Angular, MSSQL' },
+			{ name: 'ServiceNow Integration', detail: '.NET 5, Service Bus, REST APIs' },
+			{ name: 'Mobile API for Flutter App', detail: '.NET 6, Azure DevOps' },
+			{ name: 'Policy Decryption Automation', detail: '.NET 7, Azure Functions, Azure Storage' },
+		],
+	},
+	{
+		title: 'Contract Software Engineer',
+		company: 'EQALIS',
+		location: 'Remote',
+		from: 'Dec 2019',
+		to: 'Jul 2021',
+		highlights: [
+			'Designed modular web applications with Node.js, Express, and Vue.js.',
+			'Integrated external APIs including MYOB.',
+			'Improved code quality with strict gatekeeping practices.',
+			'Built hardware simulation solutions with Arduino, C#, and .NET.',
+		],
+		projects: [
+			{ name: 'MYOB Integration', detail: 'Express, TypeScript, Node.js' },
+			{ name: 'Hardware Simulation', detail: 'C#, .NET' },
+			{ name: 'EQALIS Server', detail: 'Node.js, Express, WebSockets, TypeORM' },
+		],
+	},
+	{
+		title: 'Full Stack Developer',
+		company: 'HS One',
+		location: 'Auckland',
+		from: 'Feb 2018',
+		to: 'Jul 2019',
+		highlights: [
+			'Designed containerised APIs with .NET Core and Kubernetes.',
+			'Built front-end applications in Angular and TypeScript.',
+			'Developed service simulators using .NET Framework.',
+		],
+		projects: [
+			{ name: 'Prior Approvals', detail: '.NET Core 3.1, Kubernetes, Angular' },
+			{ name: 'Orthodontics', detail: '.NET Core 3.1, Kubernetes, Angular' },
+			{ name: 'Background Services', detail: '.NET Core 3.1, Kubernetes' },
+		],
+	},
+	{
+		title: 'Full Stack Developer',
+		company: 'Private Flight Global',
+		location: 'Auckland',
+		from: 'Dec 2016',
+		to: 'Feb 2018',
+		highlights: [
+			'Designed and implemented a PDF generation module.',
+			'Implemented the repository pattern with EF Core.',
+			'Enhanced search and automated scripted workflows.',
+		],
+		projects: [
+			{ name: 'Flight Management Platform', detail: '.NET Core 2.1, .NET Framework 4.5, Angular 2' },
+			{ name: 'Platform Migration Tool', detail: '.NET Core 2.1' },
+		],
+	},
+	{
+		title: 'Software Engineer (Internships)',
+		company: 'Nazar Software / TÜBİTAK',
+		location: 'Istanbul',
+		from: 'Jun 2014 – Aug 2014',
+		to: 'Jun 2012 – Aug 2012',
+		highlights: [],
+	},
+];
 ---
 
 <!doctype html>
 <html lang="en">
-  <head>
-    <BaseHead title={`Experience | ${SITE_TITLE}`} />
-  </head>
-<body>
-  <Header />
-  <main>
-    <section style="max-width: 900px; margin: 2rem auto;">
-      <h1 style="font-size:2.2rem; margin-bottom:1.5rem; border-bottom: 2px solid #eee; padding-bottom: 0.5rem;">Work Experience</h1>
+	<head>
+		<BaseHead title={`Experience | ${SITE_TITLE}`} description="Work experience and projects of Sinan Nar." />
+	</head>
+	<body>
+		<Header />
+		<main>
+			<section class="section">
+				<p class="eyebrow">~/experience $ git log --oneline</p>
+				<h1>Work experience</h1>
+				<p class="muted">A timeline of the teams I've worked with and the systems I've helped ship.</p>
+			</section>
 
-      <!-- Senior Software Engineer | EROAD, Auckland -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Consultant</span>
-            <span style="color:#888; font-size:1rem;"> @ ARINCO, Auckland</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">June 2025 – Current</time>
-        </header>
-        <ul style="margin-top:0.7em;">
-          <!-- <li>Architecting and maintaining event-driven customer integrations using Kafka and ServiceBus, enabling seamless external system connectivity and improving data flow efficiency for business-critical operations.</li>
-          <li>Optimizing CI/CD pipelines, reducing deployment failures and increasing automation coverage, ensuring consistent and reliable release processes.</li>
-          <li>Improving developer experience by enforcing Clean Code, SOLID principles, and best practices across engineering workflows.</li>
-          <li>Designing scalable microservices-based architecture using Clean Architecture, DDD, and Kubernetes, ensuring performance, scalability, and fault tolerance.</li>
-          <li>Enhancing system monitoring using Datadog, implementing real-time dashboards and alerts mechanisms for proactive issue identification.</li>
-          <li>Leading adoption of feature flags via Azure App Configuration, enabling safer incremental releases and reducing deployment risks.</li>
-          <li>Automating infrastructure management by migrating manual resources (“click-ops”) to Terraform, reducing operational overhead and improving deployment reliability.</li>
-          <li>Conducting architecture reviews, driving strategic technical decisions that improved system scalability, maintainability, and alignment with organizational goals.</li>
-          <li>Collaborating across engineering and business teams to ensure solutions aligned with customer needs and organizational objectives.</li>
-          <li>Assisting in hiring and interview processes, mentoring candidates and ensuring skill alignment with organizational requirements.</li> -->
-        </ul>
-        <details style="margin-top:0.5em;">
-          <summary style="cursor:pointer; font-weight:500; color:#2a6ebb;">Key Projects</summary>
-          <ul>
-            <!-- <li><b>MCC</b> AI assistant integration </li>
-            <li><b>Smart Group</b> Integration Modernisation </li>
-            <li><b>FMA</b> AI Accelarator </li>
-            <li><b>Beaumont Tiles</b> AzDevOps </li>
-            <li><b>CSR</b> Identity Migration </li> -->
-          </ul>
-        </details>
-      </article>
-
-      <hr style="border:none; border-top:1px solid #eee; margin:2rem 0;"/>
-
-      <!-- Senior Software Engineer | EROAD, Auckland -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Senior Software Engineer</span>
-            <span style="color:#888; font-size:1rem;"> @ EROAD, Auckland</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">Aug 2023 – May 2025</time>
-        </header>
-        <ul style="margin-top:0.7em;">
-          <li>Architected and maintained event-driven customer integrations using Kafka and ServiceBus, enabling seamless external system connectivity and improving data flow efficiency for business-critical operations.</li>
-          <li>Optimized CI/CD pipelines, reducing deployment failures and increasing automation coverage, ensuring consistent and reliable release processes.</li>
-          <li>Improved developer experience by enforcing Clean Code, SOLID principles, and best practices across engineering workflows.</li>
-          <li>Designed scalable microservices-based architecture using Clean Architecture, DDD, and Kubernetes, ensuring performance, scalability, and fault tolerance.</li>
-          <li>Enhanced system monitoring using Datadog, implementing real-time dashboards and alerts mechanisms for proactive issue identification.</li>
-          <li>Led adoption of feature flags via Azure App Configuration, enabling safer incremental releases and reducing deployment risks.</li>
-          <li>Automated infrastructure management by migrating manual resources (“click-ops”) to Terraform, reducing operational overhead and improving deployment reliability.</li>
-          <li>Conducted architecture reviews, driving strategic technical decisions that improved system scalability, maintainability, and alignment with organizational goals.</li>
-          <li>Collaborated across engineering and business teams to ensure solutions aligned with customer needs and organizational objectives.</li>
-          <li>Assisted in hiring and interview processes, mentoring candidates and ensuring skill alignment with organizational requirements.</li>
-        </ul>
-        <details style="margin-top:0.5em;">
-          <summary style="cursor:pointer; font-weight:500; color:#2a6ebb;">Key Projects</summary>
-          <ul>
-            <li><b>Sysco Integration:</b> Architected solution using .NET 6, Kubernetes, ServiceBus, GitHub Actions, Kafka, MongoDB, and Datadog to streamline internal and external integrations.</li>
-            <li><b>Customer Integrations:</b> Delivered business-driven systems using .NET Core 3.1, Kubernetes, Azure DevOps, ServiceBus, MongoDB, and MediatR to enable reliable customer connectivity.</li>
-            <li><b>Legacy Pipeline Modernization:</b> Refactored legacy systems with .NET, Bitbucket, Azure Functions, and Azure DevOps, enhancing system reliability and compliance efforts.</li>
-          </ul>
-        </details>
-      </article>
-
-      <hr style="border:none; border-top:1px solid #eee; margin:2rem 0;"/>
-
-      <!-- Lead Software Engineer | First Rescue, Auckland -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Lead Software Engineer</span>
-            <span style="color:#888; font-size:1rem;"> @ First Rescue, Auckland</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">Jul 2019 – Aug 2023</time>
-        </header>
-        <ul style="margin-top:0.7em;">
-          <li>Led development of scalable .NET Core & Angular applications, modernizing legacy systems to improve performance and reduce technical debt.</li>
-          <li>Migrated legacy SQL databases to Azure, ensuring compliance with audit requirements and improving data security and accessibility.</li>
-          <li>Rewrote and optimized incident & policy management systems, enhancing system responsiveness and scalability to meet growing business demands.</li>
-          <li>Maintained and improved a Xamarin-based mobile application, increasing application stability and delivering a better user experience.</li>
-          <li>Integrated ServiceNow, Auto Integrity, and Linksoft, streamlining business workflows and enabling seamless communication across platforms.</li>
-          <li>Developed and optimized CI/CD pipelines in Azure DevOps, reducing deployment time and increasing pipeline success rates through automation.</li>
-          <li>Managed Azure cloud resources, achieving an optimal balance between resource cost and system performance.</li>
-        </ul>
-        <details style="margin-top:0.5em;">
-          <summary style="cursor:pointer; font-weight:500; color:#2a6ebb;">Key Projects</summary>
-          <ul>
-            <li><b>Incident Management Systems:</b> Designed scalable systems using .NET Core, Angular, and Azure DevOps, modernizing legacy workflows and boosting reliability.</li>
-            <li><b>Policy Management Systems:</b> Led development efforts with .NET Core, Angular, and MSSQL, improving scalability and maintaining compliance with regulatory standards.</li>
-            <li><b>ServiceNow Integration:</b> Delivered mission-critical integrations using .NET 5, Service Bus, and REST APIs, enabling real-time synchronization across systems.</li>
-            <li><b>Mobile API for Flutter App:</b> Developed APIs using .NET 6 and optimized deployment pipelines using Azure DevOps, supporting seamless mobile integration.</li>
-            <li><b>Policy Decryption Automation:</b> Implemented automation solutions using .NET 7, Azure Functions, and Azure Storage, reducing manual intervention and improving data accuracy.</li>
-          </ul>
-        </details>
-      </article>
-
-      <hr style="border:none; border-top:1px solid #eee; margin:2rem 0;"/>
-
-      <!-- Contract Software Engineer | EQALIS (Remote) -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Contract Software Engineer</span>
-            <span style="color:#888; font-size:1rem;"> @ EQALIS (Remote)</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">Dec 2019 – Jul 2021</time>
-        </header>
-        <ul style="margin-top:0.7em;">
-          <li>Designed modular web applications using Node.js, Express, and Vue.js, enhancing system scalability and reducing technical complexity.</li>
-          <li>Integrated external APIs, including MYOB, to expand system connectivity, streamline business workflows, and improve operational efficiency.</li>
-          <li>Improved code quality and team productivity by implementing strict gatekeeping principles and enforcing best practices, reducing code review errors.</li>
-          <li>Developed hardware simulation solutions with Arduino, C#, and .NET, enabling comprehensive testing and validation of device functionality without requiring physical hardware.</li>
-          <li>Collaborated with cross-functional teams to ensure smooth delivery of proprietary server solutions, utilizing Node.js, Express, WebSockets, and TypeORM.</li>
-        </ul>
-        <details style="margin-top:0.5em;">
-          <summary style="cursor:pointer; font-weight:500; color:#2a6ebb;">Key Projects</summary>
-          <ul>
-            <li><b>MYOB Integration:</b> Delivered seamless integrations using Express, TypeScript, and Node.js, improving system capabilities and supporting end-to-end workflows.</li>
-            <li><b>Hardware Simulation:</b> Designed simulation tools using C#, and .NET, enabling thorough testing of hardware interactions and validating system logic without physical components.</li>
-            <li><b>EQALIS Server:</b> Developed a high-performance server-side solution using Node.js, Express, WebSockets, and TypeORM, facilitating real-time communication between distributed systems.</li>
-          </ul>
-        </details>
-      </article>
-
-      <hr style="border:none; border-top:1px solid #eee; margin:2rem 0;"/>
-
-      <!-- Full Stack Developer | HS One, Auckland -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Full Stack Developer</span>
-            <span style="color:#888; font-size:1rem;"> @ HS One, Auckland</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">Feb 2018 – Jul 2019</time>
-        </header>
-        <ul style="margin-top:0.7em;">
-          <li>Designed containerized APIs using .NET Core and Kubernetes, ensuring scalability, high availability, and modularity for distributed systems.</li>
-          <li>Created and optimized front-end applications with Angular and TypeScript, streamlining workflows and enhancing user experience in customer-facing systems.</li>
-          <li>Developed service simulators using .NET Framework, enabling robust testing environments and minimizing reliance on third-party service availability.</li>
-          <li>Worked collaboratively with cross-functional teams to deliver systems aligned with business objectives, ensuring consistency and quality across microservices architecture.</li>
-        </ul>
-        <details style="margin-top:0.5em;">
-          <summary style="cursor:pointer; font-weight:500; color:#2a6ebb;">Key Projects</summary>
-          <ul>
-            <li><b>Prior Approvals:</b> (.NET Core 3.1, Kubernetes, Angular)</li>
-            <li><b>Orthodontics:</b> (.NET Core 3.1, Kubernetes, Angular)</li>
-            <li><b>Background Services:</b> (.NET Core 3.1, Kubernetes)</li>
-          </ul>
-        </details>
-      </article>
-
-      <hr style="border:none; border-top:1px solid #eee; margin:2rem 0;"/>
-
-      <!-- Full Stack Developer | Private Flight Global, Auckland -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Full Stack Developer</span>
-            <span style="color:#888; font-size:1rem;"> @ Private Flight Global, Auckland</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">Dec 2016 – Feb 2018</time>
-        </header>
-        <ul style="margin-top:0.7em;">
-          <li>Designed and implemented a PDF generation module, automating report workflows and reducing manual processing efforts.</li>
-          <li>Implemented the repository pattern with EF Core, improving data handling efficiency, scalability, and maintainability.</li>
-          <li>Enhanced search functionality, enabling faster data retrieval and significantly improving system usability for internal and client-facing applications.</li>
-          <li>Automated various scripted functions, reducing manual intervention and boosting productivity across critical processes.</li>
-          <li>Collaborated with stakeholders to identify system inefficiencies and deliver innovative, user-friendly solutions aligned with business objectives.</li>
-        </ul>
-        <details style="margin-top:0.5em;">
-          <summary style="cursor:pointer; font-weight:500; color:#2a6ebb;">Key Projects</summary>
-          <ul>
-            <li><b>Flight Management Platform:</b> Developed a modular architecture using .NET Core 2.1, .NET Framework 4.5, and Angular 2, enabling scalability for managing flight operations and improving data flow.</li>
-            <li><b>Platform Migration Tool:</b> Built a data migration tool using .NET Core 2.1, streamlining legacy system upgrades and ensuring seamless data integrity during transitions.</li>
-          </ul>
-        </details>
-      </article>
-
-      <hr style="border:none; border-top:1px solid #eee; margin:2rem 0;"/>
-
-      <!-- Software Engineer (Internships) -->
-      <article style="margin-bottom:2.5rem;">
-        <header style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap;">
-          <div>
-            <span style="font-size:1.2rem; font-weight:600;">Software Engineer (Internships)</span>
-            <span style="color:#888; font-size:1rem;"> @ Nazar Software, Istanbul & TUBITAK, Istanbul</span>
-          </div>
-          <time style="color:#666; font-size:0.95rem;">Jun 2014 – Aug 2014, Jun 2012 – Aug 2012</time>
-        </header>
-      </article>
-
-    </section>
-  </main>
-  <Footer />
-</body>
+			<section class="timeline">
+				{roles.map((role) => (
+					<article class="role">
+						<div class="role-marker" aria-hidden="true">
+							<span class={`dot ${role.current ? 'current' : ''}`}></span>
+						</div>
+						<div class="role-card">
+							<header class="role-head">
+								<div>
+									<h2 class="role-title">
+										{role.title}
+										<span class="muted at"> @ </span>
+										<span class="role-company">{role.company}</span>
+									</h2>
+									<p class="role-location mono">{role.location}</p>
+								</div>
+								<time class="role-time mono">
+									{role.from} <span class="muted">→</span> {role.to}
+								</time>
+							</header>
+							{role.highlights.length > 0 && (
+								<ul class="role-highlights">
+									{role.highlights.map((h) => <li>{h}</li>)}
+								</ul>
+							)}
+							{role.projects && role.projects.length > 0 && (
+								<details class="role-projects">
+									<summary>Key projects</summary>
+									<ul>
+										{role.projects.map((p) => (
+											<li>
+												<strong>{p.name}</strong>{p.detail ? <span class="muted"> — {p.detail}</span> : null}
+											</li>
+										))}
+									</ul>
+								</details>
+							)}
+						</div>
+					</article>
+				))}
+			</section>
+		</main>
+		<Footer />
+	</body>
 </html>
+
+<style>
+	.timeline {
+		max-width: 900px;
+		margin: 1.5rem auto 0;
+		display: flex;
+		flex-direction: column;
+		gap: 1.25rem;
+		position: relative;
+	}
+	.timeline::before {
+		content: '';
+		position: absolute;
+		left: 9px;
+		top: 6px;
+		bottom: 6px;
+		width: 1px;
+		background: linear-gradient(180deg, transparent, var(--border) 8%, var(--border) 92%, transparent);
+	}
+	.role {
+		display: grid;
+		grid-template-columns: 20px 1fr;
+		gap: 1rem;
+		align-items: start;
+	}
+	.role-marker {
+		display: grid;
+		place-items: center;
+		padding-top: 18px;
+	}
+	.dot {
+		width: 11px;
+		height: 11px;
+		border-radius: 999px;
+		background: var(--border-strong);
+		border: 2px solid var(--bg);
+		box-shadow: 0 0 0 1px var(--border);
+	}
+	.dot.current {
+		background: var(--prompt);
+		box-shadow: 0 0 0 1px var(--prompt), 0 0 14px var(--prompt);
+	}
+	.role-card {
+		background: var(--surface);
+		border: 1px solid var(--border);
+		border-radius: var(--radius-lg);
+		padding: 1rem 1.1rem 1.1rem;
+		box-shadow: var(--shadow-1);
+	}
+	.role-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-start;
+		gap: 1rem;
+		flex-wrap: wrap;
+		margin-bottom: 0.6rem;
+	}
+	.role-title { margin: 0; font-size: 1.1rem; }
+	.role-company { color: var(--accent); }
+	.role-location { margin: 0.15rem 0 0; color: var(--text-muted); font-size: 0.82rem; }
+	.role-time { color: var(--text-muted); font-size: 0.85rem; white-space: nowrap; }
+	.role-highlights { margin: 0.4rem 0 0; padding-left: 1.2em; }
+	.role-highlights li { margin: 0.25em 0; }
+	.role-projects { margin-top: 0.6rem; }
+	.role-projects summary {
+		cursor: pointer;
+		color: var(--accent);
+		font-family: var(--font-mono);
+		font-size: 0.9rem;
+		padding: 0.3rem 0;
+	}
+	.role-projects ul { margin: 0.4rem 0 0; padding-left: 1.2em; }
+	.at { font-weight: 400; }
+</style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,26 @@
 ---
-import BaseHead from "../components/BaseHead.astro";
-import Header from "../components/Header.astro";
-import Footer from "../components/Footer.astro";
-import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
+import Footer from '../components/Footer.astro';
+import TerminalWindow from '../components/TerminalWindow.astro';
+import MvpBadge from '../components/MvpBadge.astro';
+import FormattedDate from '../components/FormattedDate.astro';
+import { SITE_TITLE, SITE_DESCRIPTION, SITE_TAGLINE } from '../consts';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog'))
+	.filter((p) => !p.id.startsWith('unused/'))
+	.sort((a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+	.slice(0, 4);
+
+const skills = [
+	{ group: '.NET & C#', items: ['.NET 6+', '.NET Aspire', 'ASP.NET', 'EF Core'] },
+	{ group: 'Azure', items: ['App Services', 'Functions', 'Container Apps', 'AKS', 'Service Bus', 'KeyVault'] },
+	{ group: 'Frontend', items: ['TypeScript', 'Angular', 'Ionic', 'Node.js'] },
+	{ group: 'DevOps', items: ['GitHub Actions', 'Azure DevOps', 'Terraform', 'Docker', 'Kubernetes'] },
+	{ group: 'Data', items: ['MSSQL', 'PostgreSQL', 'CosmosDB', 'MongoDB'] },
+	{ group: 'Observability', items: ['Datadog', 'Azure Monitor', 'App Insights'] },
+];
 ---
 
 <!doctype html>
@@ -11,79 +29,152 @@ import { SITE_TITLE, SITE_DESCRIPTION } from "../consts";
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
 		<script type="text/javascript">
 			(function (c, l, a, r, i, t, y) {
-				c[a] =
-					c[a] ||
-					function () {
-						(c[a].q = c[a].q || []).push(arguments);
-					};
-				t = l.createElement(r);
-				t.async = 1;
-				t.src = "https://www.clarity.ms/tag/" + i;
-				y = l.getElementsByTagName(r)[0];
-				y.parentNode.insertBefore(t, y);
-			})(window, document, "clarity", "script", "s5jfnsazxg");
+				c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments); };
+				t = l.createElement(r); t.async = 1; t.src = 'https://www.clarity.ms/tag/' + i;
+				y = l.getElementsByTagName(r)[0]; y.parentNode.insertBefore(t, y);
+			})(window, document, 'clarity', 'script', 's5jfnsazxg');
 		</script>
 	</head>
 	<body>
 		<Header />
 		<main>
-			<section style="margin-bottom: 2rem;">
-				<h1 style="font-size:2.5rem; margin-bottom:0.5rem;">
-					Sinan Nar
-				</h1>
-				<h2
-					style="font-size:1.5rem; color: #666; margin-bottom:1.5rem;"
-				>
-					Senior Software Engineer & Technical Leader
-				</h2>
-				<p style="max-width: 700px;">
-					I am a Consultant who focuses on an Apps and AI. I am working at ARINCO which is Microsoft and GitHub partner consultancy. I co-organise the Aotearoa Azure User Group and the Auckland .NET User Group. I am an experienced and certified software engineer, specialise in the Microsoft ecosystem, with a focus on Azure and GitHub.
-				</p>
-				<!-- Social/contact links moved to Header and Footer -->
-				<hr style="margin:2rem 0;" />
-				<div
-					style="display: flex; flex-wrap: wrap; gap: 2rem; margin-bottom: 2rem;"
-				>
-					<div style="flex: 1 1 250px; min-width: 220px;">
-						<h3>What I Work With</h3>
-						<p style="margin: 0 0 0.5em 0;">
-							.NET (Core & 6+), C#, JavaScript, TypeScript,
-							Angular, Ionic, Node.js
-						</p>
-						<p style="margin: 0 0 0.5em 0;">
-							Kubernetes, Docker, Azure (App Services, Functions,
-							Service Bus, AKS, Container Apps, KeyVault)
-						</p>
-						<p style="margin: 0 0 0.5em 0;">
-							CI/CD (GitHub Actions, Azure DevOps), Terraform,
-							Integration Testing, TDD, BDD
-						</p>
-						<p style="margin: 0 0 0.5em 0;">
-							SQL (MSSQL, PostgreSQL, MySQL), MongoDB, CosmosDB,
-							Datadog, Azure Monitor
-						</p>
+			<!-- Hero -->
+			<section class="hero">
+				<TerminalWindow title="sinannar@nz:~">
+					<p class="hero-line"><span class="prompt">whoami</span></p>
+					<h1 class="hero-name">Sinan Nar<span class="caret" aria-hidden="true"></span></h1>
+					<p class="hero-tagline mono">{SITE_TAGLINE}</p>
+					<p class="hero-bio">
+						Consultant focused on Apps and AI. Working at <a href="https://arinco.com.au" target="_blank" rel="noopener">ARINCO</a>,
+						a Microsoft and GitHub partner consultancy. I co-organise the Aotearoa Azure Meetup, the
+						Auckland .NET User Group, and the Aotearoa NZ GitHub User Group — and I'm an experienced,
+						certified software engineer in the Microsoft ecosystem with a focus on Azure and GitHub.
+					</p>
+
+					<div class="hero-mvp">
+						<MvpBadge variant="block" />
 					</div>
-					<div style="flex: 1 1 250px; min-width: 220px;">
-						<h3>How I Work</h3>
-						<ul style="margin: 0; padding-left: 1.2em;">
-							<li>
-								Clear, friendly communication with all
-								stakeholders
-							</li>
-							<li>Collaborative and supportive team player</li>
-							<li>Mentor and coach for junior developers</li>
-							<li>Proactive problem solver and decision maker</li>
-							<li>Strong time management and prioritization</li>
-							<li>Always learning and sharing knowledge</li>
-						</ul>
+
+					<div class="hero-actions">
+						<a class="btn primary" href="/blog">read the blog →</a>
+						<a class="btn" href="/speaking">see talks</a>
+						<a class="btn" href="/experience">experience</a>
 					</div>
+				</TerminalWindow>
+			</section>
+
+			<!-- Stack -->
+			<section class="section">
+				<p class="eyebrow">~/ $ cat stack.txt</p>
+				<div class="grid stack-grid">
+					{skills.map((s) => (
+						<TerminalWindow title={s.group}>
+							<ul class="tag-list">
+								{s.items.map((i) => <li class="tag">{i}</li>)}
+							</ul>
+						</TerminalWindow>
+					))}
 				</div>
 			</section>
-			<section>
-				<a href="/blog" style="font-size:1.2rem;">Read my Blog &rarr;</a
-				>
+
+			<!-- Recent posts -->
+			<section class="section">
+				<div class="section-head">
+					<p class="eyebrow">~/blog $ ls -t | head -4</p>
+					<a class="link-more" href="/blog">view all →</a>
+				</div>
+				<ul class="post-list">
+					{posts.map((post) => (
+						<li>
+							<a class="post-row" href={`/blog/${post.id}/`}>
+								<span class="post-prompt" aria-hidden="true">❯</span>
+								<span class="post-title">{post.data.title}</span>
+								<span class="post-date mono"><FormattedDate date={post.data.pubDate} /></span>
+							</a>
+						</li>
+					))}
+				</ul>
 			</section>
 		</main>
 		<Footer />
 	</body>
 </html>
+
+<style>
+	.hero { margin-top: 1.5rem; }
+	.hero-line { margin: 0 0 0.6rem; }
+	.hero-name {
+		margin: 0.2rem 0 0.4rem;
+		font-size: clamp(2rem, 3vw + 1rem, 3rem);
+		letter-spacing: -0.01em;
+	}
+	.hero-tagline { color: var(--text-muted); margin: 0 0 1rem; }
+	.hero-bio { max-width: 64ch; }
+	.hero-mvp { margin: 1.25rem 0 1.5rem; }
+	.hero-actions { display: flex; flex-wrap: wrap; gap: 0.6rem; }
+
+	.grid { display: grid; gap: 1rem; }
+	.stack-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+	@media (max-width: 900px) { .stack-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); } }
+	@media (max-width: 560px) { .stack-grid { grid-template-columns: 1fr; } }
+
+	.tag-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.4rem;
+	}
+	.tag {
+		display: inline-flex;
+		align-items: center;
+		padding: 0.2rem 0.55rem;
+		font-family: var(--font-mono);
+		font-size: 0.82rem;
+		color: var(--text);
+		background: var(--surface-2);
+		border: 1px solid var(--border);
+		border-radius: 999px;
+	}
+
+	.section-head {
+		display: flex;
+		align-items: baseline;
+		justify-content: space-between;
+		gap: 1rem;
+		margin-bottom: 0.75rem;
+	}
+	.link-more {
+		font-family: var(--font-mono);
+		font-size: 0.85rem;
+	}
+	.post-list { list-style: none; padding: 0; margin: 0; }
+	.post-row {
+		display: grid;
+		grid-template-columns: auto 1fr auto;
+		align-items: baseline;
+		gap: 0.7rem;
+		padding: 0.7rem 0.85rem;
+		border: 1px solid var(--border);
+		border-radius: var(--radius);
+		background: var(--surface);
+		color: var(--text);
+		text-decoration: none;
+		margin-bottom: 0.5rem;
+		transition: border-color 120ms ease, background 120ms ease, transform 120ms ease;
+	}
+	.post-row:hover {
+		border-color: var(--accent);
+		background: var(--surface-2);
+		text-decoration: none;
+		transform: translateX(2px);
+	}
+	.post-prompt { color: var(--prompt); font-family: var(--font-mono); }
+	.post-title { color: var(--text); }
+	.post-date { color: var(--text-muted); font-size: 0.85rem; }
+	@media (max-width: 560px) {
+		.post-row { grid-template-columns: auto 1fr; }
+		.post-date { grid-column: 1 / -1; padding-left: 1.6rem; }
+	}
+</style>

--- a/src/pages/speaking.astro
+++ b/src/pages/speaking.astro
@@ -245,21 +245,18 @@ const organizerGroups = [
   <body>
     <Header />
     <main>
-      <section style="max-width: 900px; margin: 2rem auto;">
-        <h1
-          style="font-size:2.2rem; margin-bottom:1.5rem; border-bottom: 2px solid #eee; padding-bottom: 0.5rem;"
-        >
-          Public Speaking &amp; Meetups
-        </h1>
+      <section class="section page-section">
+        <p class="eyebrow">~/speaking $ ls -1</p>
+        <h1>Public speaking &amp; meetups</h1>
+        <p class="muted">Talks I've given and groups I help organise across Aotearoa.</p>
 
-        <!-- Speaking Engagements -->
-        <h2 style="font-size:1.5rem; margin-bottom:1rem;">Public Speakings</h2>
+        <h2 class="section-title">Talks</h2>
 
         <ul class="talks-list">
           {talks.map((talk) => <TalkFlipCard {...talk} />)}
         </ul>
 
-        <h2 style="font-size:1.5rem; margin-bottom:1rem;">YouTube Recordings</h2>
+        <h2 class="section-title">YouTube recordings</h2>
 
         {
           recordings.length > 0 ? (
@@ -275,7 +272,7 @@ const organizerGroups = [
       
 
         <!-- Organiser Groups -->
-        <h2 style="font-size:1.5rem; margin-bottom:1rem;">Organizer for</h2>
+        <h2 class="section-title">Organiser for</h2>
 
         <ul class="group-list">
           {organizerGroups.map((group) => <OrganizerCard {...group} />)}
@@ -287,13 +284,23 @@ const organizerGroups = [
 </html>
 
 <style>
+  .page-section { max-width: 980px; margin: 0 auto; }
+  .section-title {
+    font-family: var(--font-mono);
+    font-size: 1.25rem;
+    margin: 2rem 0 1rem;
+    color: var(--text);
+    border-bottom: 1px dashed var(--border);
+    padding-bottom: 0.5rem;
+  }
+
   .page-warning {
     margin: 0 0 1.5rem;
     padding: 0.75rem 0.95rem;
     border-radius: 10px;
-    border: 1px solid #facc15;
-    background: #fffbeb;
-    color: #854d0e;
+    border: 1px solid var(--yellow);
+    background: var(--surface-2);
+    color: var(--text);
     font-size: 0.95rem;
     font-weight: 600;
   }
@@ -303,7 +310,7 @@ const organizerGroups = [
     padding: 0;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2rem;
+    gap: 1.25rem;
     margin-bottom: 2.5rem;
   }
 
@@ -312,7 +319,7 @@ const organizerGroups = [
     padding: 0;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2rem;
+    gap: 1.25rem;
     margin-bottom: 2.5rem;
   }
 
@@ -321,47 +328,29 @@ const organizerGroups = [
     padding: 0;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 2rem;
+    gap: 1.25rem;
     margin-bottom: 2.5rem;
   }
 
   .section-empty-state {
     margin: 0 0 2.5rem;
     padding: 1rem 1.1rem;
-    border: 1px dashed rgba(148, 163, 184, 0.9);
-    border-radius: 16px;
-    background: linear-gradient(180deg, #fff 0%, #f8fafc 100%);
-    color: #475569;
+    border: 1px dashed var(--border-strong);
+    border-radius: var(--radius);
+    background: var(--surface);
+    color: var(--text-muted);
     font-size: 0.95rem;
   }
 
   @media (max-width: 720px) {
-    .group-list {
-      grid-template-columns: 1fr;
-      gap: 1.5rem;
-    }
-
-    .talks-list {
-      grid-template-columns: 1fr;
-      gap: 1.5rem;
-    }
-
-    .recordings-list {
-      grid-template-columns: 1fr;
-    }
+    .group-list,
+    .talks-list { grid-template-columns: 1fr; gap: 1rem; }
+    .recordings-list { grid-template-columns: 1fr; }
   }
 
   @media (max-width: 1024px) and (min-width: 721px) {
-    .group-list {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .talks-list {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .recordings-list {
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
+    .group-list,
+    .talks-list,
+    .recordings-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,144 +1,411 @@
 /*
-  The CSS in this style tag is based off of Bear Blog's default CSS.
-  https://github.com/HermanMartinus/bearblog/blob/297026a877bc2ab2b3bdfbd6b9f7961c350917dd/templates/styles/blog/default.css
-  License MIT: https://github.com/HermanMartinus/bearblog/blob/master/LICENSE.md
- */
+  Global styles — terminal / TUI aesthetic.
+  Dark "terminal" theme is the default; light "paper" theme via [data-theme="light"].
+*/
 
-:root {
-	--accent: #2337ff;
-	--accent-dark: #000d8a;
-	--black: 15, 18, 25;
-	--gray: 96, 115, 159;
-	--gray-light: 229, 233, 240;
-	--gray-dark: 34, 41, 57;
-	--gray-gradient: rgba(var(--gray-light), 50%), #fff;
-	--box-shadow:
-		0 2px 6px rgba(var(--gray), 25%), 0 8px 24px rgba(var(--gray), 33%),
-		0 16px 32px rgba(var(--gray), 33%);
+:root,
+:root[data-theme='dark'] {
+	color-scheme: dark;
+	--bg: #0d1117;
+	--bg-elev: #0f1622;
+	--surface: #161b22;
+	--surface-2: #1c2230;
+	--border: #30363d;
+	--border-strong: #3d444d;
+	--text: #e6edf3;
+	--text-muted: #8b949e;
+	--text-faint: #6e7681;
+	--prompt: #3fb950;
+	--accent: #58a6ff;
+	--accent-soft: rgba(88, 166, 255, 0.16);
+	--magenta: #d2a8ff;
+	--yellow: #f7c948;
+	--orange: #ff9b6e;
+	--mvp: #ff5b3a;
+	--mvp-soft: rgba(255, 91, 58, 0.16);
+	--selection: rgba(63, 185, 80, 0.32);
+	--shadow-1: 0 1px 0 rgba(255, 255, 255, 0.03), 0 8px 24px rgba(0, 0, 0, 0.55);
+	--shadow-2: 0 1px 0 rgba(255, 255, 255, 0.04), 0 16px 48px rgba(0, 0, 0, 0.65);
+	--glow: 0 0 0 1px rgba(88, 166, 255, 0.25), 0 0 24px rgba(88, 166, 255, 0.18);
+	--ring: 0 0 0 2px rgba(63, 185, 80, 0.6);
+
+	--radius: 10px;
+	--radius-lg: 14px;
+	--radius-sm: 6px;
+
+	--font-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, Consolas, 'Liberation Mono', monospace;
+	--font-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+
+	--max-page: 1080px;
+	--max-content: 760px;
+
+	color: var(--text);
+	background: var(--bg);
 }
-@font-face {
-	font-family: 'Atkinson';
-	src: url('/fonts/atkinson-regular.woff') format('woff');
-	font-weight: 400;
-	font-style: normal;
-	font-display: swap;
+
+:root[data-theme='light'] {
+	color-scheme: light;
+	--bg: #fafafa;
+	--bg-elev: #ffffff;
+	--surface: #ffffff;
+	--surface-2: #f4f6fa;
+	--border: #d0d7de;
+	--border-strong: #b6becc;
+	--text: #1f2328;
+	--text-muted: #57606a;
+	--text-faint: #6e7781;
+	--prompt: #1a7f37;
+	--accent: #0969da;
+	--accent-soft: rgba(9, 105, 218, 0.12);
+	--magenta: #8250df;
+	--yellow: #9a6700;
+	--orange: #bc4c00;
+	--mvp: #bf3917;
+	--mvp-soft: rgba(191, 57, 23, 0.12);
+	--selection: rgba(26, 127, 55, 0.22);
+	--shadow-1: 0 1px 0 rgba(15, 23, 42, 0.04), 0 8px 20px rgba(15, 23, 42, 0.08);
+	--shadow-2: 0 2px 0 rgba(15, 23, 42, 0.05), 0 18px 36px rgba(15, 23, 42, 0.12);
+	--glow: 0 0 0 1px rgba(9, 105, 218, 0.22), 0 0 24px rgba(9, 105, 218, 0.15);
+	--ring: 0 0 0 2px rgba(26, 127, 55, 0.45);
 }
-@font-face {
-	font-family: 'Atkinson';
-	src: url('/fonts/atkinson-bold.woff') format('woff');
-	font-weight: 700;
-	font-style: normal;
-	font-display: swap;
+
+/* No-FOUC: respected via inline script in BaseHead */
+
+*,
+*::before,
+*::after {
+	box-sizing: border-box;
 }
+
+html {
+	scroll-behavior: smooth;
+}
+
 body {
-	font-family: 'Atkinson', sans-serif;
 	margin: 0;
 	padding: 0;
-	text-align: left;
-	background: linear-gradient(var(--gray-gradient)) no-repeat;
-	background-size: 100% 600px;
+	min-height: 100vh;
+	background:
+		radial-gradient(1200px 600px at 50% -200px, var(--accent-soft), transparent 60%),
+		var(--bg);
+	color: var(--text);
+	font-family: var(--font-sans);
+	font-size: 17px;
+	line-height: 1.65;
+	-webkit-font-smoothing: antialiased;
+	text-rendering: optimizeLegibility;
 	word-wrap: break-word;
 	overflow-wrap: break-word;
-	color: rgb(var(--gray-dark));
-	font-size: 18px;
-	line-height: 1.7;
 }
-main {
-	width: 720px;
-	max-width: calc(100% - 2em);
-	margin: auto;
-	padding: 3em 1em;
+
+::selection {
+	background: var(--selection);
+	color: var(--text);
 }
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-	margin: 0 0 0 0;
-	color: rgb(var(--black));
-	line-height: 1.2;
-}
-h1 {
-	font-size: 2.5em;
-}
-h2 {
-	font-size: 2em;
-}
-h3 {
-	font-size: 1.6em;
-}
-h4 {
-	font-size: 1.4em;
-}
-h5 {
-	font-size: 1.1em;
-}
-h6 {
-	font-size: 0.8em;
-}
-strong,
-b {
-	font-weight: 700;
-}
+
 a {
 	color: var(--accent);
+	text-decoration: none;
+	text-underline-offset: 3px;
+	transition: color 120ms ease, text-decoration-color 120ms ease;
 }
 a:hover {
-	color: var(--accent);
+	text-decoration: underline;
+	text-decoration-color: var(--accent);
 }
-p {
-	margin-bottom: 1em;
+a:focus-visible,
+button:focus-visible,
+[tabindex]:focus-visible {
+	outline: none;
+	box-shadow: var(--ring);
+	border-radius: var(--radius-sm);
 }
-.prose p {
-	margin-bottom: 2em;
-}
-textarea {
+
+main {
 	width: 100%;
-	font-size: 16px;
+	max-width: var(--max-page);
+	margin: 0 auto;
+	padding: 2.5rem 1.25rem 4rem;
 }
-input {
-	font-size: 16px;
+
+h1, h2, h3, h4, h5, h6 {
+	font-family: var(--font-mono);
+	color: var(--text);
+	line-height: 1.2;
+	margin: 0 0 0.6em;
+	letter-spacing: -0.01em;
 }
-table {
-	width: 100%;
+h1 { font-size: clamp(1.9rem, 2.4vw + 1rem, 2.6rem); font-weight: 700; }
+h2 { font-size: clamp(1.4rem, 1.4vw + 1rem, 1.9rem); font-weight: 700; }
+h3 { font-size: 1.25rem; font-weight: 600; }
+h4 { font-size: 1.1rem; font-weight: 600; }
+h5 { font-size: 1rem; font-weight: 600; }
+h6 { font-size: 0.9rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; color: var(--text-muted); }
+
+p { margin: 0 0 1em; }
+strong, b { font-weight: 700; color: var(--text); }
+em, i { font-style: italic; }
+
+ul, ol { margin: 0 0 1em; padding-left: 1.4em; }
+li { margin: 0.25em 0; }
+
+hr {
+	border: none;
+	border-top: 1px dashed var(--border);
+	margin: 2rem 0;
 }
+
 img {
 	max-width: 100%;
 	height: auto;
-	border-radius: 8px;
+	border-radius: var(--radius);
+	display: block;
 }
+
+/* Code */
 code {
-	padding: 2px 5px;
-	background-color: rgb(var(--gray-light));
-	border-radius: 2px;
+	font-family: var(--font-mono);
+	font-size: 0.92em;
+	padding: 0.15em 0.4em;
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-sm);
+	color: var(--text);
 }
 pre {
-	padding: 1.5em;
-	border-radius: 8px;
+	font-family: var(--font-mono);
+	font-size: 0.92em;
+	padding: 1.1rem 1.2rem;
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	overflow-x: auto;
+	box-shadow: var(--shadow-1);
+	tab-size: 2;
 }
 pre > code {
 	all: unset;
+	font-family: inherit;
 }
-blockquote {
-	border-left: 4px solid var(--accent);
-	padding: 0 0 0 20px;
-	margin: 0px;
-	font-size: 1.333em;
+pre.astro-code {
+	background: var(--surface) !important;
 }
-hr {
-	border: none;
-	border-top: 1px solid rgb(var(--gray-light));
-}
-@media (max-width: 720px) {
-	body {
-		font-size: 18px;
-	}
-	main {
-		padding: 1em;
-	}
+:root[data-theme='light'] pre.astro-code,
+:root[data-theme='light'] pre.astro-code span {
+	color: inherit;
 }
 
+/* Show the right Shiki theme per mode */
+:root[data-theme='dark'] .astro-code,
+:root[data-theme='dark'] .astro-code span {
+	color: var(--shiki-dark, inherit) !important;
+	background-color: var(--shiki-dark-bg, var(--surface)) !important;
+	font-style: var(--shiki-dark-font-style, inherit) !important;
+	font-weight: var(--shiki-dark-font-weight, inherit) !important;
+	text-decoration: var(--shiki-dark-text-decoration, inherit) !important;
+}
+
+blockquote {
+	margin: 1.5rem 0;
+	padding: 0.6rem 1.1rem;
+	border-left: 3px solid var(--prompt);
+	background: var(--surface);
+	border-radius: 0 var(--radius) var(--radius) 0;
+	color: var(--text-muted);
+	font-style: italic;
+}
+
+table {
+	width: 100%;
+	border-collapse: collapse;
+	margin: 1.5rem 0;
+	border: 1px solid var(--border);
+	border-radius: var(--radius);
+	overflow: hidden;
+	font-size: 0.95em;
+}
+th, td {
+	padding: 0.7em 0.9em;
+	text-align: left;
+	border-bottom: 1px solid var(--border);
+}
+th {
+	background: var(--surface-2);
+	font-family: var(--font-mono);
+	color: var(--text);
+}
+tr:last-child td { border-bottom: none; }
+
+input, textarea, button, select {
+	font-family: inherit;
+	font-size: 1rem;
+	color: inherit;
+}
+
+/* Scrollbar */
+* {
+	scrollbar-color: var(--border-strong) transparent;
+	scrollbar-width: thin;
+}
+*::-webkit-scrollbar { width: 10px; height: 10px; }
+*::-webkit-scrollbar-thumb {
+	background: var(--border-strong);
+	border-radius: 999px;
+}
+
+/* Terminal prompt accents */
+.prompt {
+	font-family: var(--font-mono);
+	color: var(--prompt);
+	font-weight: 700;
+}
+.prompt::before {
+	content: '❯ ';
+	color: var(--accent);
+}
+.caret {
+	display: inline-block;
+	width: 0.55ch;
+	height: 1em;
+	background: var(--prompt);
+	margin-left: 2px;
+	transform: translateY(2px);
+	animation: blink 1.05s steps(2, end) infinite;
+}
+@keyframes blink {
+	0%, 50% { opacity: 1; }
+	50.01%, 100% { opacity: 0; }
+}
+
+/* Section helpers */
+.section { margin: 2.5rem 0; }
+.eyebrow {
+	font-family: var(--font-mono);
+	font-size: 0.8rem;
+	text-transform: uppercase;
+	letter-spacing: 0.12em;
+	color: var(--text-muted);
+	margin: 0 0 0.6em;
+}
+.muted { color: var(--text-muted); }
+.mono { font-family: var(--font-mono); }
+
+/* Prose container (used on blog posts) */
+.prose {
+	max-width: var(--max-content);
+	margin: 0 auto;
+}
+.prose p { margin-bottom: 1.15em; }
+.prose img {
+	margin: 1.25rem auto;
+	border-radius: var(--radius);
+	border: 1px solid var(--border);
+}
+.prose pre { margin: 1.25rem 0; max-height: 800px; }
+.prose h2 { margin-top: 2.2em; }
+.prose h3 { margin-top: 1.8em; }
+.prose a { color: var(--accent); }
+.prose ul, .prose ol { margin-bottom: 1.25em; }
+
+/* Generic terminal window card */
+.terminal {
+	background: var(--surface);
+	border: 1px solid var(--border);
+	border-radius: var(--radius-lg);
+	box-shadow: var(--shadow-1);
+	overflow: hidden;
+}
+.terminal-bar {
+	display: flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.55rem 0.85rem;
+	background: var(--surface-2);
+	border-bottom: 1px solid var(--border);
+	font-family: var(--font-mono);
+	font-size: 0.8rem;
+	color: var(--text-muted);
+}
+.terminal-dots {
+	display: inline-flex;
+	gap: 6px;
+	margin-right: 0.5rem;
+}
+.terminal-dot {
+	width: 11px;
+	height: 11px;
+	border-radius: 999px;
+	background: var(--border-strong);
+}
+.terminal-dot.red { background: #ff5f57; }
+.terminal-dot.yellow { background: #febc2e; }
+.terminal-dot.green { background: #28c840; }
+.terminal-body {
+	padding: 1.25rem 1.25rem 1.4rem;
+}
+.terminal-body p:last-child { margin-bottom: 0; }
+
+/* Pill / chip */
+.chip {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.4rem;
+	padding: 0.25rem 0.6rem;
+	font-family: var(--font-mono);
+	font-size: 0.78rem;
+	color: var(--text);
+	background: var(--surface-2);
+	border: 1px solid var(--border);
+	border-radius: 999px;
+}
+.chip.mvp {
+	color: var(--mvp);
+	background: var(--mvp-soft);
+	border-color: var(--mvp);
+}
+.chip .dot {
+	width: 6px;
+	height: 6px;
+	border-radius: 999px;
+	background: currentColor;
+	box-shadow: 0 0 8px currentColor;
+}
+
+/* Buttons */
+.btn {
+	display: inline-flex;
+	align-items: center;
+	gap: 0.5rem;
+	padding: 0.55rem 0.95rem;
+	font-family: var(--font-mono);
+	font-size: 0.9rem;
+	color: var(--text);
+	background: var(--surface);
+	border: 1px solid var(--border-strong);
+	border-radius: var(--radius);
+	cursor: pointer;
+	transition: transform 120ms ease, background 120ms ease, border-color 120ms ease;
+	text-decoration: none;
+}
+.btn:hover {
+	background: var(--surface-2);
+	border-color: var(--accent);
+	color: var(--text);
+	text-decoration: none;
+}
+.btn:active { transform: translateY(1px); }
+.btn.primary {
+	color: var(--bg);
+	background: var(--prompt);
+	border-color: var(--prompt);
+}
+.btn.primary:hover {
+	background: var(--prompt);
+	color: var(--bg);
+	filter: brightness(1.1);
+}
+
+/* Screen-reader only */
 .sr-only {
 	border: 0;
 	padding: 0;
@@ -147,59 +414,21 @@ hr {
 	height: 1px;
 	width: 1px;
 	overflow: hidden;
-	/* IE6, IE7 - a 0 height clip, off to the bottom right of the visible 1px box */
-	clip: rect(1px 1px 1px 1px);
-	/* maybe deprecated but we need to support legacy browsers */
 	clip: rect(1px, 1px, 1px, 1px);
-	/* modern browsers, clip-path works inwards from each corner */
 	clip-path: inset(50%);
-	/* added line to stop words getting smushed together (as they go onto separate lines and some screen readers do not understand line feeds as a space */
 	white-space: nowrap;
 }
 
-.prose pre {
-	max-height: 800px;
-	overflow-y: auto;
-	overflow-x: auto;
-	padding: 1.5em;
-	border-radius: 8px;
+/* Responsive */
+@media (max-width: 720px) {
+	body { font-size: 16px; }
+	main { padding: 1.5rem 1rem 3rem; }
 }
 
-
-table {
-	border: #000d8a solid;
-	border-radius: 20px;
-	border-width: 3px;
-	padding: 30px;
-
-	margin-top: 2rem;
-	margin-bottom: 2rem;
-
-	width: 160%;
-	max-width: 160%;
-	transform: translateX(-20%);
-}
-
-.hero-image img {
-	width: 250px;
-	height: auto;
-}
-
-li img {
-	width: 250px;
-	height: auto;
-}
-
-hr {
-	width: 160%;
-	max-width: 160%;
-	transform: translateX(-20%);
-
-	margin-top: 2rem;
-	margin-bottom: 2rem;
-
-	border: none;      /* remove default border */
-	height: 4px;       /* thickness */
-	background-color: #333; /* color of the line */
-	margin: 2rem auto; /* vertical spacing + center */
+/* Reduce motion */
+@media (prefers-reduced-motion: reduce) {
+	*, *::before, *::after {
+		animation-duration: 0.001ms !important;
+		transition-duration: 0.001ms !important;
+	}
 }


### PR DESCRIPTION
Refreshes the personal blog so it feels more modern, easier to read and navigate, and reflects a new Microsoft MVP award. The previous design relied on inline styles and a Bear-Blog-derived stylesheet; this PR introduces a coherent design system with a terminal / TUI aesthetic that matches the "developer brand" and gives code-heavy posts more room to breathe.

## Approach

- **Design system.** A token-based `global.css` with a dark-first "terminal" theme and a light "paper" theme. The theme is set via `data-theme` on the root, persisted in `localStorage`, and respects `prefers-color-scheme` on first load. A no-FOUC inline script in `BaseHead` applies it before paint. Typography moves to JetBrains Mono (headings, code, nav prompts) + Inter (body prose).
- **New shared components.** `TerminalWindow` (reusable card with traffic-light header), `MvpBadge` (inline chip + a block variant linking to the MVP profile), and a rebuilt sticky `Header` with prompt-style brand, mobile nav drawer, and a theme toggle. `Footer` matches the new look.
- **Pages.**
  - `index.astro` rebuilt as a terminal session with an MVP "achievement" block, a stack grid, and a recent-posts list.
  - `about.astro` rewritten with real bio content (the lorem ipsum is gone) and an MVP block.
  - `blog/index.astro` reworked as terminal-window cards with hero thumbnails.
  - `BlogPost.astro` gets refined prose, a sticky on-page TOC on desktop, and Shiki dark/light code themes.
  - `experience.astro` converted from inline styles to a scoped CSS vertical timeline with a live "current role" marker.
  - `certifications.astro` converted to a responsive grid with the MVP block pinned at the top.
  - `speaking.astro` keeps its content but moves off inline section styles to match the new tokens.
- **Infra.** Re-wired `@astrojs/mdx` and `@astrojs/sitemap` integrations in `astro.config.mjs` (they were imported but never registered), and configured Shiki dual themes (`github-light` / `github-dark-dimmed`). Centralised `SITE_*`, `MVP_URL`, and `SOCIAL_LINKS` in `src/consts.ts`.

## Notes for review

- No new framework. Still Astro + vanilla CSS, no Tailwind. The only new runtime dependency is Google Fonts via `<link>` in `BaseHead.astro`.
- The header's mobile nav and theme toggle use small inline `is:inline` scripts so they work without bundling.
- Existing post content is untouched.
- `npm run build` passes locally: 15 pages generated.